### PR TITLE
Use generated Prisma client import

### DIFF
--- a/apps/api/src/prisma.service.ts
+++ b/apps/api/src/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from './prisma/generated/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 


### PR DESCRIPTION
### Motivation
- `generator client` in `apps/api/prisma/schema.prisma` emits the client to `../src/prisma/generated/client`, so the runtime import must match the generated output.
- Prevent a mismatch between the generated client path and the package import `@prisma/client` which would break type resolution or runtime imports.
- Ensure TypeScript can resolve the generated client types from the `apps/api/src/prisma/generated/client` path.

### Description
- Changed the import in `apps/api/src/prisma.service.ts` from `@prisma/client` to the relative path `./prisma/generated/client`.
- Kept all `PrismaClient` usage and configuration unchanged, including the `PrismaPg` adapter and logging settings.
- No other files were modified in this change.

### Testing
- No automated tests were run for this change.
- No CI/build steps were executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a047ad5f48327bd3b23b3e1345680)