### PR TITLE
fix: update API_URL fallback to production URL

### DIFF
--- a/apps/web/src/app/setup/github/page.tsx
+++ b/apps/web/src/app/setup/github/page.tsx
@@ -26,7 +26,7 @@ import { MainLayout } from '@/components/layout';
 import { FiGithub, FiCopy, FiCheck, FiExternalLink, FiSave } from 'react-icons/fi';
 import { useState, useEffect, useCallback } from 'react';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://factrail-production.up.railway.app';
 
 interface SettingResponse {
   id: string;


### PR DESCRIPTION
## 概要

GitHub設定ページがAPI_URLのフォールバックとして`localhost:3001`を使用していたため、本番環境でWebhook Secretの保存が失敗していました。

Factsページと同じく本番URL(`https://factrail-production.up.railway.app`)をフォールバックとして使用するように修正しました。

## 変更内容

- `apps/web/src/app/setup/github/page.tsx`のAPI_URLフォールバック値を更新

## 関連Issue

Closes #2

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/sode0417/factrail/actions/runs/21334394453