### PR TITLE
fix: GitHub webhook経由のFactがSlack投稿されない問題を修正 (#22)

### DIFF
--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { SettingsService } from '../settings/settings.service';
 import { PrismaService } from '../prisma.service';
@@ -54,6 +56,7 @@ export class WebhooksService {
   constructor(
     private readonly settingsService: SettingsService,
     private readonly prisma: PrismaService,
+    @InjectQueue('slack-dispatch') private readonly slackQueue: Queue,
   ) {}
 
   /**
@@ -246,6 +249,7 @@ export class WebhooksService {
 
   /**
    * Fact を作成または更新（同じ externalId があれば更新）
+   * Fact作成後、Slack投稿キューにジョブを追加
    */
   private async upsertFact(data: {
     externalId: string;
@@ -259,7 +263,7 @@ export class WebhooksService {
     metadata: Record<string, unknown>;
     raw: unknown;
   }) {
-    return this.prisma.fact.upsert({
+    const fact = await this.prisma.fact.upsert({
       where: {
         source_externalId: {
           source: data.source,
@@ -277,7 +281,6 @@ export class WebhooksService {
         type: data.type,
         metadata: data.metadata as Prisma.InputJsonValue,
         raw: data.raw as Prisma.InputJsonValue,
-        processedAt: new Date(),
       },
       update: {
         sourceUrl: data.sourceUrl,
@@ -288,9 +291,26 @@ export class WebhooksService {
         type: data.type,
         metadata: data.metadata as Prisma.InputJsonValue,
         raw: data.raw as Prisma.InputJsonValue,
-        processedAt: new Date(),
       },
     });
+
+    // Slack投稿されていない場合、キューにジョブを追加
+    if (!fact.slackMessageId) {
+      await this.slackQueue.add(
+        'send-dm',
+        { factId: fact.id },
+        {
+          attempts: 5,
+          backoff: {
+            type: 'exponential',
+            delay: 1000,
+          },
+        },
+      );
+      this.logger.log(`Slack投稿キューにジョブを追加: Fact ID=${fact.id}`);
+    }
+
+    return fact;
   }
 
   /**


### PR DESCRIPTION
## 概要
GitHub webhook経由で作成されたFactがSlack投稿されない問題を修正しました。

## 問題の原因
`WebhooksService` が `FactsService.create()` を使わずに直接 `prisma.fact.upsert()` を呼んでいたため、Slack投稿キューにジョブが追加されていませんでした。

### 問題のあったフロー
```
GitHub Webhook受信
  ↓
WebhooksService.upsertFact() → Prisma.fact.upsert()
  ↓
❌ キューにジョブが追加されない
  ↓
❌ Slack投稿が実行されない
```

## 修正内容

### 1. Slackキューの注入
- `@nestjs/bull` から `InjectQueue` と `Queue` をインポート
- `WebhooksService` のコンストラクタに `slackQueue: Queue` を注入

### 2. キューへのジョブ追加ロジックを実装
- `upsertFact()` メソッドで、Fact作成/更新後に `slackMessageId` が null の場合、Slackキューにジョブを追加
- リトライ設定（最大5回、指数バックオフ）を適用

### 3. processedAt の自動設定を削除
- Fact作成時の `processedAt` 自動設定を削除
- `processedAt` は Slack投稿完了時に `SlackDispatcherProcessor` で設定されるべき

### 修正後のフロー
```
GitHub Webhook受信
  ↓
WebhooksService.upsertFact() → Prisma.fact.upsert() + slackQueue.add()
  ↓
✅ キューにジョブが追加
  ↓
✅ SlackDispatcherProcessor.handleSendDM()
  ↓
✅ Slack投稿が実行される
```

## テスト計画
- [ ] GitHub issueを作成してwebhookをトリガー
- [ ] Railwayログで「Slack投稿キューにジョブを追加」メッセージを確認
- [ ] Slackで対象チャンネル/DMにメッセージが投稿されることを確認
- [ ] DBでFactレコードの `slackMessageId` と `processedAt` が設定されることを確認

## 関連Issue
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)