### PR TITLE
feat: Factsページでリアルタイムデータ表示

### DIFF
--- a/apps/web/src/app/facts/page.tsx
+++ b/apps/web/src/app/facts/page.tsx
@@ -21,6 +21,7 @@ import { MainLayout } from '@/components/layout';
 import { FiSearch, FiExternalLink, FiRefreshCw } from 'react-icons/fi';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+import { formatRelativeTime } from '@/lib/formatRelativeTime';
 
 interface Fact {
   id: string;
@@ -67,20 +68,29 @@ function formatDate(dateString: string): string {
   });
 }
 
+// ポーリング間隔（30秒）
+const POLLING_INTERVAL = 30000;
+
 export default function FactsPage() {
   const [facts, setFacts] = useState<Fact[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isBackgroundUpdate, setIsBackgroundUpdate] = useState(false);
   const [sourceFilter, setSourceFilter] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'https://factrail-production.up.railway.app';
 
-  const fetchFacts = async () => {
-    setLoading(true);
+  const fetchFacts = async (isBackground = false) => {
+    if (!isBackground) {
+      setLoading(true);
+    } else {
+      setIsBackgroundUpdate(true);
+    }
+
     try {
       const params = new URLSearchParams();
       if (sourceFilter) params.append('source', sourceFilter);
-      
+
       const response = await axios.get<FactsResponse>(
         `${apiUrl}/api/facts?${params.toString()}`
       );
@@ -89,11 +99,25 @@ export default function FactsPage() {
       console.error('Failed to fetch facts:', error);
     } finally {
       setLoading(false);
+      setIsBackgroundUpdate(false);
     }
   };
 
+  // 初回ロードとフィルター変更時のフェッチ
   useEffect(() => {
     fetchFacts();
+  }, [sourceFilter]);
+
+  // 30秒ごとのポーリング
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      fetchFacts(true);
+    }, POLLING_INTERVAL);
+
+    // クリーンアップ
+    return () => {
+      clearInterval(intervalId);
+    };
   }, [sourceFilter]);
 
   const filteredFacts = facts.filter((fact) => {
@@ -139,10 +163,10 @@ export default function FactsPage() {
             </Select>
 
             <Button
-              leftIcon={<FiRefreshCw />}
+              leftIcon={<FiRefreshCw className={isBackgroundUpdate ? 'animate-spin' : ''} />}
               variant="outline"
               colorScheme="gray"
-              onClick={fetchFacts}
+              onClick={() => fetchFacts(false)}
               isLoading={loading}
             >
               更新
@@ -205,7 +229,7 @@ export default function FactsPage() {
                           {fact.type}
                         </Badge>
                         <Text fontSize="xs" color="gray.500">
-                          {formatDate(fact.occurredAt)}
+                          {formatRelativeTime(fact.occurredAt)} ({formatDate(fact.occurredAt)})
                         </Text>
                       </HStack>
                     </Box>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -15,10 +15,14 @@ import {
   VStack,
   HStack,
   Badge,
+  Spinner,
 } from '@chakra-ui/react';
 import { MainLayout } from '@/components/layout';
 import { FiDatabase, FiGithub, FiMessageSquare, FiActivity } from 'react-icons/fi';
 import { IconType } from 'react-icons';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { formatRelativeTime } from '@/lib/formatRelativeTime';
 
 interface StatCardProps {
   label: string;
@@ -53,30 +57,29 @@ function StatCard({ label, value, helpText, icon, color }: StatCardProps) {
   );
 }
 
-interface RecentActivityItem {
+interface Fact {
   id: string;
-  title: string;
+  externalId: string;
   source: string;
+  sourceUrl: string | null;
+  occurredAt: string;
+  title: string;
+  summary: string | null;
   type: string;
-  time: string;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
 }
 
-const mockRecentActivity: RecentActivityItem[] = [
-  {
-    id: '1',
-    title: 'API動作確認テスト',
-    source: 'manual',
-    type: 'note',
-    time: '2分前',
-  },
-  {
-    id: '2',
-    title: 'Supabase → Prisma Studio 接続テスト',
-    source: 'supabase-manual',
-    type: 'test.supabase_created',
-    time: '8日前',
-  },
-];
+interface FactsResponse {
+  data: Fact[];
+  meta: {
+    hasMore: boolean;
+    nextCursor?: string;
+  };
+}
+
+// ポーリング間隔（30秒）
+const POLLING_INTERVAL = 30000;
 
 function getSourceColor(source: string): string {
   switch (source) {
@@ -92,14 +95,63 @@ function getSourceColor(source: string): string {
 }
 
 export default function DashboardPage() {
+  const [facts, setFacts] = useState<Fact[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'https://factrail-production.up.railway.app';
+
+  const fetchFacts = async () => {
+    try {
+      const response = await axios.get<FactsResponse>(
+        `${apiUrl}/api/facts?limit=5`
+      );
+      setFacts(response.data.data);
+    } catch (error) {
+      console.error('Failed to fetch facts:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 初回ロード
+  useEffect(() => {
+    fetchFacts();
+  }, []);
+
+  // 30秒ごとのポーリング
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      fetchFacts();
+    }, POLLING_INTERVAL);
+
+    // クリーンアップ
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  // 統計情報を計算
+  const totalFacts = facts.length;
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+  const factsLast30Days = facts.filter(
+    (fact) => new Date(fact.occurredAt) >= thirtyDaysAgo
+  ).length;
+
+  const factsToday = facts.filter(
+    (fact) => new Date(fact.occurredAt) >= oneDayAgo
+  ).length;
+
   return (
     <MainLayout title="ダッシュボード" subtitle="Factrailの概要を確認">
       {/* Stats Grid */}
       <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} spacing={6} mb={8}>
         <StatCard
           label="総Facts数"
-          value="2"
-          helpText="過去30日間で+2"
+          value={loading ? '-' : totalFacts.toString()}
+          helpText={`過去30日間で+${factsLast30Days}`}
           icon={FiDatabase}
           color="brand"
         />
@@ -119,7 +171,7 @@ export default function DashboardPage() {
         />
         <StatCard
           label="今日のアクティビティ"
-          value="1"
+          value={loading ? '-' : factsToday.toString()}
           helpText="直近24時間"
           icon={FiActivity}
           color="accent"
@@ -132,45 +184,55 @@ export default function DashboardPage() {
           <Text fontSize="lg" fontWeight="semibold" mb={4}>
             最近のアクティビティ
           </Text>
-          <VStack spacing={4} align="stretch">
-            {mockRecentActivity.map((item) => (
-              <Flex
-                key={item.id}
-                p={4}
-                bg="gray.900"
-                borderRadius="lg"
-                justify="space-between"
-                align="center"
-              >
-                <HStack spacing={4}>
-                  <Box
-                    w={2}
-                    h={10}
-                    borderRadius="full"
-                    bg={`${getSourceColor(item.source)}.500`}
-                  />
-                  <Box>
-                    <Text fontWeight="medium">{item.title}</Text>
-                    <HStack spacing={2} mt={1}>
-                      <Badge
-                        colorScheme={getSourceColor(item.source)}
-                        variant="subtle"
-                        fontSize="xs"
-                      >
-                        {item.source}
-                      </Badge>
-                      <Text fontSize="xs" color="gray.500">
-                        {item.type}
-                      </Text>
-                    </HStack>
-                  </Box>
-                </HStack>
-                <Text fontSize="sm" color="gray.500">
-                  {item.time}
-                </Text>
-              </Flex>
-            ))}
-          </VStack>
+          {loading ? (
+            <Flex justify="center" py={10}>
+              <Spinner size="lg" color="brand.500" />
+            </Flex>
+          ) : facts.length === 0 ? (
+            <Flex justify="center" py={10}>
+              <Text color="gray.500">アクティビティがありません</Text>
+            </Flex>
+          ) : (
+            <VStack spacing={4} align="stretch">
+              {facts.map((fact) => (
+                <Flex
+                  key={fact.id}
+                  p={4}
+                  bg="gray.900"
+                  borderRadius="lg"
+                  justify="space-between"
+                  align="center"
+                >
+                  <HStack spacing={4}>
+                    <Box
+                      w={2}
+                      h={10}
+                      borderRadius="full"
+                      bg={`${getSourceColor(fact.source)}.500`}
+                    />
+                    <Box>
+                      <Text fontWeight="medium">{fact.title}</Text>
+                      <HStack spacing={2} mt={1}>
+                        <Badge
+                          colorScheme={getSourceColor(fact.source)}
+                          variant="subtle"
+                          fontSize="xs"
+                        >
+                          {fact.source}
+                        </Badge>
+                        <Text fontSize="xs" color="gray.500">
+                          {fact.type}
+                        </Text>
+                      </HStack>
+                    </Box>
+                  </HStack>
+                  <Text fontSize="sm" color="gray.500">
+                    {formatRelativeTime(fact.occurredAt)}
+                  </Text>
+                </Flex>
+              ))}
+            </VStack>
+          )}
         </CardBody>
       </Card>
     </MainLayout>

--- a/apps/web/src/lib/formatRelativeTime.ts
+++ b/apps/web/src/lib/formatRelativeTime.ts
@@ -1,0 +1,35 @@
+/**
+ * 相対時間を日本語でフォーマットする関数
+ * @param dateString ISO8601形式の日時文字列
+ * @returns 相対時間の文字列（例: "たった今", "2分前", "3時間前"）
+ */
+export function formatRelativeTime(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffWeeks = Math.floor(diffDays / 7);
+  const diffMonths = Math.floor(diffDays / 30);
+  const diffYears = Math.floor(diffDays / 365);
+
+  if (diffSeconds < 10) {
+    return 'たった今';
+  } else if (diffSeconds < 60) {
+    return `${diffSeconds}秒前`;
+  } else if (diffMinutes < 60) {
+    return `${diffMinutes}分前`;
+  } else if (diffHours < 24) {
+    return `${diffHours}時間前`;
+  } else if (diffDays < 7) {
+    return `${diffDays}日前`;
+  } else if (diffWeeks < 4) {
+    return `${diffWeeks}週間前`;
+  } else if (diffMonths < 12) {
+    return `${diffMonths}ヶ月前`;
+  } else {
+    return `${diffYears}年前`;
+  }
+}


### PR DESCRIPTION
## 概要
Factsページで実際のAPIデータを表示し、リアルタイム更新を実装

## 実装内容
- 相対時間フォーマッター作成
- Factsページに30秒ごとのポーリング機能追加
- Factsページに相対時間表示追加
- ダッシュボードページのモックデータ削除
- ダッシュボードに相対時間表示とポーリング機能追加
- ローディング状態の改善
- 更新ボタンを保持

Closes #7

Generated with [Claude Code](https://claude.ai/code)