### PR TITLE
feat: Integrations APIのレスポンス形式を仕様書に準拠

### DIFF
--- a/apps/api/src/integrations/integrations.controller.ts
+++ b/apps/api/src/integrations/integrations.controller.ts
@@ -52,12 +52,14 @@ export class IntegrationsController {
    * 全てのIntegrationを取得する
    */
   @Get()
-  async findAll(@Query('provider') provider?: string): Promise<IntegrationResponse[]> {
+  async findAll(@Query('provider') provider?: string): Promise<{ data: IntegrationResponse[] }> {
     const integrations = provider
       ? await this.integrationsService.findByProvider(provider)
       : await this.integrationsService.findAll();
 
-    return integrations.map((integration) => this.toResponse(integration));
+    return {
+      data: integrations.map((integration) => this.toResponse(integration)),
+    };
   }
 
   /**
@@ -85,9 +87,10 @@ export class IntegrationsController {
    * Integrationを削除する
    */
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async remove(@Param('id') id: string): Promise<void> {
+  @HttpCode(HttpStatus.OK)
+  async remove(@Param('id') id: string): Promise<{ success: boolean }> {
     await this.integrationsService.remove(id);
+    return { success: true };
   }
 
   /**


### PR DESCRIPTION
Closes #8

## 概要
連携サービス（GitHub, Slack）の管理機能APIを仕様書に準拠させるよう修正

## 変更内容
- GET /integrations を `{ data: [...] }` 形式に変更
- DELETE /integrations/:id を `{ success: true }` 形式に変更
- HTTPステータスを204から200に変更

## 参照
- docs/factrail-API.md


Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/sode0417/factrail/tree/claude/issue-8-20260130-1744) | [View job run](https://github.com/sode0417/factrail/actions/runs/21525102771