### PR TITLE
fix(dashboard): 今日のアクティビティ数を正確に表示するよう修正

### DIFF
--- a/apps/api/src/facts/dto/index.ts
+++ b/apps/api/src/facts/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './query-facts.dto';
 export * from './create-fact.dto';
+export * from './stats-response.dto';

--- a/apps/api/src/facts/dto/stats-response.dto.ts
+++ b/apps/api/src/facts/dto/stats-response.dto.ts
@@ -1,0 +1,14 @@
+/**
+ * 記録の統計情報レスポンス
+ * 将来的に週次・月次の統計も追加可能な構造
+ */
+export class FactsStatsResponseDto {
+  /** 今日（直近24時間）の記録数 */
+  todayCount: number;
+
+  // 将来的に追加予定:
+  // /** 過去7日間の記録数 */
+  // last7DaysCount?: number;
+  // /** 過去30日間の記録数 */
+  // last30DaysCount?: number;
+}

--- a/apps/api/src/facts/facts.controller.ts
+++ b/apps/api/src/facts/facts.controller.ts
@@ -21,6 +21,15 @@ export class FactsController {
   constructor(private readonly factsService: FactsService) {}
 
   /**
+   * 記録の統計情報を取得する
+   * @returns 今日（直近24時間）の記録数
+   */
+  @Get('stats')
+  getStats() {
+    return this.factsService.getStats();
+  }
+
+  /**
    * 記録の一覧を取得する（カーソルベースページネーション）
    * @param query 検索条件（ソース、タイプ、日時範囲、ページング情報）
    * @returns ページングされた記録のリスト

--- a/apps/api/src/facts/facts.service.ts
+++ b/apps/api/src/facts/facts.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { PrismaService } from '../prisma.service';
-import { CreateFactDto, QueryFactsDto } from './dto';
+import { CreateFactDto, QueryFactsDto, FactsStatsResponseDto } from './dto';
 import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
@@ -140,5 +140,27 @@ export class FactsService {
     );
 
     return { data: fact };
+  }
+
+  /**
+   * 記録の統計情報を取得する
+   * @returns 今日（直近24時間）の記録数
+   */
+  async getStats(): Promise<FactsStatsResponseDto> {
+    const now = new Date();
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    // 今日（直近24時間）の記録数を取得
+    const todayCount = await this.prisma.fact.count({
+      where: {
+        occurredAt: {
+          gte: oneDayAgo,
+        },
+      },
+    });
+
+    return {
+      todayCount,
+    };
   }
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -18,7 +18,7 @@ import {
   Spinner,
 } from '@chakra-ui/react';
 import { MainLayout } from '@/components/layout';
-import { FiDatabase, FiGithub, FiMessageSquare, FiActivity } from 'react-icons/fi';
+import { FiGithub, FiMessageSquare, FiActivity } from 'react-icons/fi';
 import { IconType } from 'react-icons';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
@@ -78,6 +78,10 @@ interface FactsResponse {
   };
 }
 
+interface FactsStatsResponse {
+  todayCount: number;
+}
+
 // ポーリング間隔（30秒）
 const POLLING_INTERVAL = 30000;
 
@@ -96,6 +100,7 @@ function getSourceColor(source: string): string {
 
 export default function DashboardPage() {
   const [facts, setFacts] = useState<Fact[]>([]);
+  const [stats, setStats] = useState<FactsStatsResponse>({ todayCount: 0 });
   const [loading, setLoading] = useState(true);
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'https://factrail-production.up.railway.app';
@@ -113,15 +118,28 @@ export default function DashboardPage() {
     }
   };
 
+  const fetchStats = async () => {
+    try {
+      const response = await axios.get<FactsStatsResponse>(
+        `${apiUrl}/api/facts/stats`
+      );
+      setStats(response.data);
+    } catch (error) {
+      console.error('Failed to fetch stats:', error);
+    }
+  };
+
   // 初回ロード
   useEffect(() => {
     fetchFacts();
+    fetchStats();
   }, []);
 
   // 30秒ごとのポーリング
   useEffect(() => {
     const intervalId = setInterval(() => {
       fetchFacts();
+      fetchStats();
     }, POLLING_INTERVAL);
 
     // クリーンアップ
@@ -130,30 +148,16 @@ export default function DashboardPage() {
     };
   }, []);
 
-  // 統計情報を計算
-  const totalFacts = facts.length;
-  const now = new Date();
-  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-
-  const factsLast30Days = facts.filter(
-    (fact) => new Date(fact.occurredAt) >= thirtyDaysAgo
-  ).length;
-
-  const factsToday = facts.filter(
-    (fact) => new Date(fact.occurredAt) >= oneDayAgo
-  ).length;
-
   return (
     <MainLayout title="ダッシュボード" subtitle="Factrailの概要を確認">
       {/* Stats Grid */}
-      <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} spacing={6} mb={8}>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6} mb={8}>
         <StatCard
-          label="総Facts数"
-          value={loading ? '-' : totalFacts.toString()}
-          helpText={`過去30日間で+${factsLast30Days}`}
-          icon={FiDatabase}
-          color="brand"
+          label="今日のアクティビティ"
+          value={loading ? '-' : stats.todayCount.toString()}
+          helpText="直近24時間"
+          icon={FiActivity}
+          color="accent"
         />
         <StatCard
           label="GitHub連携"
@@ -168,13 +172,6 @@ export default function DashboardPage() {
           helpText="設定が必要です"
           icon={FiMessageSquare}
           color="green"
-        />
-        <StatCard
-          label="今日のアクティビティ"
-          value={loading ? '-' : factsToday.toString()}
-          helpText="直近24時間"
-          icon={FiActivity}
-          color="accent"
         />
       </SimpleGrid>
 


### PR DESCRIPTION
## 概要

ダッシュボードの「今日のアクティビティ数」が正確に表示されるよう修正しました。

## 変更内容

- `GET /api/facts/stats` エンドポイントを追加
- DBレベルで今日（直近24時間）の記録数を集計
- フロントエンドで新しい統計APIを利用
- 総Facts数カードを削除（不要な機能のたあ）
- 将来的に週次・月次の統計も追加可能な構造

Fixes #56

Generated with [Claude Code](https://claude.ai/code)