### PR TITLE
fix: GitHub連携のリポジトリ所有者マッチング機能を実装

### DIFF
--- a/apps/api/src/webhooks/webhooks.service.spec.ts
+++ b/apps/api/src/webhooks/webhooks.service.spec.ts
@@ -21,6 +21,7 @@ describe('WebhooksService', () => {
     },
     integration: {
       findMany: jest.fn(),
+      findFirst: jest.fn(),
     },
   };
 
@@ -120,7 +121,7 @@ describe('WebhooksService', () => {
       id: 'int-1',
       userId: 'user-123',
       provider: 'github',
-      accountId: 'gh-123',
+      accountId: 'test',
       user: { id: 'user-123' },
     };
 
@@ -143,7 +144,7 @@ describe('WebhooksService', () => {
     };
 
     beforeEach(() => {
-      mockPrismaService.integration.findMany.mockResolvedValue([mockIntegration]);
+      mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
       mockPrismaService.fact.upsert.mockResolvedValue(mockFact);
       mockSlackQueue.add.mockResolvedValue({});
     });
@@ -210,7 +211,7 @@ describe('WebhooksService', () => {
       });
 
       it('GitHub連携が見つからない場合はnullを返すこと', async () => {
-        mockPrismaService.integration.findMany.mockResolvedValue([]);
+        mockPrismaService.integration.findFirst.mockResolvedValue(null);
 
         const result = await service.processGitHubEvent('issues', issuePayload);
 
@@ -402,10 +403,10 @@ describe('WebhooksService', () => {
         id: 'int-1',
         userId,
         provider: 'github',
-        accountId: 'gh-123',
+        accountId: 'test',
         user: { id: userId },
       };
-      mockPrismaService.integration.findMany.mockResolvedValue([mockIntegration]);
+      mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
 
       const issuePayload = {
         action: 'opened',
@@ -454,10 +455,10 @@ describe('WebhooksService', () => {
         id: 'int-1',
         userId,
         provider: 'github',
-        accountId: 'gh-123',
+        accountId: 'test',
         user: { id: userId },
       };
-      mockPrismaService.integration.findMany.mockResolvedValue([mockIntegration]);
+      mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
 
       const issuePayload = {
         action: 'opened',
@@ -479,6 +480,128 @@ describe('WebhooksService', () => {
       await service.processGitHubEvent('issues', issuePayload);
 
       expect(slackQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findUserIdForGitHubEvent (repository owner matching)', () => {
+    it('リポジトリ所有者がGitHub連携のaccountIdと一致する場合、userIdを返すこと', async () => {
+      const mockIntegration = {
+        id: 'int-1',
+        userId: 'user-123',
+        provider: 'github',
+        accountId: 'sode0417',
+        user: { id: 'user-123' },
+      };
+      mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
+      mockPrismaService.fact.upsert.mockResolvedValue({
+        id: 'fact-1',
+        userId: 'user-123',
+        slackMessageId: null,
+      });
+
+      const issuePayload = {
+        action: 'opened',
+        issue: {
+          number: 123,
+          title: 'Test Issue',
+          html_url: 'https://github.com/sode0417/factrail/issues/123',
+          user: { login: 'testuser' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+        repository: {
+          full_name: 'sode0417/factrail',
+          html_url: 'https://github.com/sode0417/factrail',
+        },
+        sender: { login: 'testuser' },
+      };
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toEqual({ factId: 'fact-1' });
+      expect(mockPrismaService.integration.findFirst).toHaveBeenCalledWith({
+        where: {
+          provider: 'github',
+          accountId: 'sode0417',
+        },
+        include: { user: true },
+      });
+    });
+
+    it('リポジトリ所有者がGitHub連携のaccountIdと一致しない場合、nullを返すこと', async () => {
+      mockPrismaService.integration.findFirst.mockResolvedValue(null);
+
+      const issuePayload = {
+        action: 'opened',
+        issue: {
+          number: 123,
+          title: 'Test Issue',
+          html_url: 'https://github.com/otheruser/repo/issues/123',
+          user: { login: 'testuser' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+        repository: {
+          full_name: 'otheruser/repo',
+          html_url: 'https://github.com/otheruser/repo',
+        },
+        sender: { login: 'testuser' },
+      };
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toBeNull();
+      expect(mockPrismaService.integration.findFirst).toHaveBeenCalledWith({
+        where: {
+          provider: 'github',
+          accountId: 'otheruser',
+        },
+        include: { user: true },
+      });
+    });
+
+    it('組織リポジトリの場合、組織名でマッチングすること', async () => {
+      const mockIntegration = {
+        id: 'int-1',
+        userId: 'user-123',
+        provider: 'github',
+        accountId: 'myorg',
+        user: { id: 'user-123' },
+      };
+      mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
+      mockPrismaService.fact.upsert.mockResolvedValue({
+        id: 'fact-1',
+        userId: 'user-123',
+        slackMessageId: null,
+      });
+
+      const issuePayload = {
+        action: 'opened',
+        issue: {
+          number: 123,
+          title: 'Test Issue',
+          html_url: 'https://github.com/myorg/project/issues/123',
+          user: { login: 'testuser' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+        repository: {
+          full_name: 'myorg/project',
+          html_url: 'https://github.com/myorg/project',
+        },
+        sender: { login: 'testuser' },
+      };
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toEqual({ factId: 'fact-1' });
+      expect(mockPrismaService.integration.findFirst).toHaveBeenCalledWith({
+        where: {
+          provider: 'github',
+          accountId: 'myorg',
+        },
+        include: { user: true },
+      });
     });
   });
 });

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -121,23 +121,35 @@ export class WebhooksService {
 
   /**
    * GitHubリポジトリに紐付くユーザーIDを取得する
-   * リポジトリ名からユーザーを特定できない場合、最初に見つかったGitHub連携ユーザーを返す
+   * リポジトリ名からowner (username/org) を抽出し、Integration.accountIdとマッチングする
    */
   private async findUserIdForGitHubEvent(repository: string): Promise<string | null> {
-    // GitHubのIntegrationからユーザーを検索
-    // 複数のユーザーがGitHub連携している可能性があるため、最初に見つかったユーザーを使用
-    const integrations = await this.prisma.integration.findMany({
-      where: { provider: 'github' },
-      include: { user: true },
-      take: 1,
-    });
+    // リポジトリ名から所有者を抽出 (例: "sode0417/factrail" -> "sode0417")
+    const owner = repository.split('/')[0];
 
-    if (integrations.length === 0) {
-      this.logger.warn(`GitHub連携が見つかりません。Factを作成できません: ${repository}`);
+    if (!owner) {
+      this.logger.error(`無効なリポジトリ名形式です: ${repository}`);
       return null;
     }
 
-    return integrations[0].userId;
+    // GitHub accountId (username/org) でマッチング
+    const integration = await this.prisma.integration.findFirst({
+      where: {
+        provider: 'github',
+        accountId: owner,
+      },
+      include: { user: true },
+    });
+
+    if (!integration) {
+      this.logger.warn(
+        `GitHub連携が見つかりません。Factを作成できません: ${repository} (所有者: ${owner})\n` +
+          `ヒント: /auth/github にアクセスして、GitHubアカウント "${owner}" で認証を行ってください。`,
+      );
+      return null;
+    }
+
+    return integration.userId;
   }
 
   /**


### PR DESCRIPTION
### 概要

GitHub連携の不具合を修正しました。`findUserIdForGitHubEvent()`メソッドがリポジトリ情報を使用せず、常に最初のGitHub連携を返す問題を解決しました。

### 変更内容

- リポジトリ名から所有者を抽出し、`Integration.accountId`とマッチングするように変更
- `findMany`から`findFirst`に変更し、より効率的なクエリに改善
- エラーメッセージに所有者情報と認証方法のヒントを追加
- テストケースを追加し、リポジトリ所有者マッチングの動作を検証

Fixes #62

---

Generated with [Claude Code](https://claude.ai/code)