### PR TITLE
feat: @nestjs/throttlerによるレート制限実装 (#79)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { BullModule } from '@nestjs/bull';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaService } from './prisma.service';
@@ -18,6 +20,24 @@ import { DispatchersModule } from './dispatchers/dispatchers.module';
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    // グローバルレート制限設定
+    ThrottlerModule.forRoot([
+      {
+        name: 'short',
+        ttl: 1000, // 1秒
+        limit: 3, // 1秒に3リクエストまで
+      },
+      {
+        name: 'medium',
+        ttl: 10000, // 10秒
+        limit: 20, // 10秒に20リクエストまで
+      },
+      {
+        name: 'long',
+        ttl: 60000, // 1分
+        limit: 100, // 1分に100リクエストまで
+      },
+    ]),
     // Redis + Bull Queue のグローバル設定
     BullModule.forRootAsync({
       imports: [ConfigModule],
@@ -46,6 +66,14 @@ import { DispatchersModule } from './dispatchers/dispatchers.module';
     WebhooksModule,
   ],
   controllers: [AppController],
-  providers: [AppService, PrismaService],
+  providers: [
+    AppService,
+    PrismaService,
+    // グローバルレート制限ガード
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Post, Body, Get, Req, Res, UseGuards, Headers } from '@nestjs/common';
 import { Response, Request } from 'express';
+import { Throttle, SkipThrottle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LocalAuthGuard } from './guards/local-auth.guard';
@@ -45,16 +46,20 @@ export class AuthController {
 
   /**
    * メール/パスワードで新規登録
+   * レート制限: 1分に5回まで（ブルートフォース対策）
    */
   @Post('register')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);
   }
 
   /**
    * メール/パスワードでログイン
+   * レート制限: 1分に5回まで（ブルートフォース対策）
    */
   @Post('login')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @UseGuards(LocalAuthGuard)
   async login(@Req() req: Request, @Headers('user-agent') userAgent?: string) {
     const user = req.user as any;

--- a/apps/api/src/webhooks/webhooks.controller.ts
+++ b/apps/api/src/webhooks/webhooks.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Post, Headers, Body, Req, HttpCode, HttpStatus, Logger } from '@nestjs/common';
 import { Request } from 'express';
+import { SkipThrottle } from '@nestjs/throttler';
 import { WebhooksService } from './webhooks.service';
 
 @Controller('webhooks')
+@SkipThrottle() // 外部サービスからのWebhookはレート制限から除外
 export class WebhooksController {
   private readonly logger = new Logger(WebhooksController.name);
 


### PR DESCRIPTION
## Summary
- ThrottlerModuleをグローバルに設定（多層レート制限）
- 認証エンドポイントに厳格なレート制限を適用（1分に5回）
- Webhookエンドポイントをレート制限から除外

## レート制限設定

| 名前 | TTL | リクエスト数 |
|------|-----|--------------|
| short | 1秒 | 3 |
| medium | 10秒 | 20 |
| long | 1分 | 100 |
| login/register | 1分 | 5 |

## 関連Issue
Closes #79
Closes partially #74

## Test plan
- [ ] 連続リクエストでレート制限が動作することを確認
- [ ] 認証エンドポイントで厳格な制限が適用されることを確認
- [ ] Webhookエンドポイントがレート制限から除外されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)