### PR TITLE
feat: helmetミドルウェアによるセキュリティヘッダー追加 (#83)

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -27,6 +27,7 @@
         "cookie-parser": "^1.4.7",
         "dotenv": "^17.2.3",
         "express-session": "^1.18.0",
+        "helmet": "^8.1.0",
         "ioredis": "^5.9.1",
         "jsonwebtoken": "^9.0.2",
         "passport": "^0.7.0",
@@ -6372,6 +6373,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,7 @@
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.2.3",
     "express-session": "^1.18.0",
+    "helmet": "^8.1.0",
     "ioredis": "^5.9.1",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,9 +4,25 @@ import { AppModule } from './app.module';
 import { GlobalExceptionFilter } from './common/filters';
 import { json, Request } from 'express';
 import * as cookieParser from 'cookie-parser';
+import helmet from 'helmet';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bodyParser: false });
+
+  // Security headers (helmet)
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          scriptSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:', 'https:'],
+        },
+      },
+      crossOriginEmbedderPolicy: false, // API用に無効化
+    }),
+  );
 
   // Cookie parser for secure token handling
   app.use(cookieParser());


### PR DESCRIPTION
## Summary
- helmetパッケージをインストール
- main.tsにhelmetミドルウェアを追加
- Content-Security-Policyをカスタマイズ

## 設定されるセキュリティヘッダー

| ヘッダー | 効果 |
|----------|------|
| X-Content-Type-Options | MIMEスニッフィング防止 |
| X-Frame-Options | Clickjacking防止 |
| X-XSS-Protection | XSS攻撃軽減 |
| Strict-Transport-Security | HTTPS強制 |
| Content-Security-Policy | スクリプト/スタイル制限 |

## 関連Issue
Closes #83
Closes partially #74

## Test plan
- [ ] レスポンスヘッダーにセキュリティヘッダーが含まれることを確認
- [ ] APIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)