### PR TITLE
fix: SettingsControllerのユーザー分離バグを修正

### DIFF
--- a/apps/api/prisma/migrations/20260215000000_migrate_global_settings_to_user/migration.sql
+++ b/apps/api/prisma/migrations/20260215000000_migrate_global_settings_to_user/migration.sql
@@ -1,0 +1,39 @@
+-- Migrate global settings (user_id=NULL) to the correct user
+-- Settings were incorrectly saved without user_id due to controller bug
+
+-- Strategy:
+-- 1. For each provider, find the user who has an integration for that provider
+-- 2. Assign the global settings to that user
+-- 3. If no matching integration exists, assign to the oldest user as fallback
+
+-- Step 1: Assign settings to users who have matching integrations
+UPDATE factrail.settings s
+SET user_id = i.user_id
+FROM factrail.integrations i
+WHERE s.user_id IS NULL
+  AND s.provider = i.provider
+  AND i.user_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM factrail.settings s2
+    WHERE s2.user_id = i.user_id
+      AND s2.provider = s.provider
+      AND s2.setting_type = s.setting_type
+  );
+
+-- Step 2: For remaining global settings with no matching integration,
+-- assign to the oldest user (fallback)
+UPDATE factrail.settings s
+SET user_id = (
+  SELECT id FROM factrail.users ORDER BY created_at ASC LIMIT 1
+)
+WHERE s.user_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM factrail.settings s2
+    WHERE s2.user_id = (SELECT id FROM factrail.users ORDER BY created_at ASC LIMIT 1)
+      AND s2.provider = s.provider
+      AND s2.setting_type = s.setting_type
+  );
+
+-- Step 3: Delete any remaining orphaned global settings that would cause
+-- unique constraint violations (already have a user-specific version)
+DELETE FROM factrail.settings WHERE user_id IS NULL;

--- a/apps/api/src/settings/settings.controller.spec.ts
+++ b/apps/api/src/settings/settings.controller.spec.ts
@@ -59,7 +59,7 @@ describe('SettingsController', () => {
       const result = await controller.upsert(mockRequest, createDto);
 
       expect(result).toEqual(mockSettingResponse);
-      expect(service.upsert).toHaveBeenCalledWith(createDto);
+      expect(service.upsert).toHaveBeenCalledWith(createDto, 'user-1');
     });
 
     it('レスポンスに値が含まれないこと', async () => {
@@ -121,13 +121,13 @@ describe('SettingsController', () => {
   });
 
   describe('findOne', () => {
-    it('特定の設定を取得できること', async () => {
+    it('特定の設定を取得できること（ユーザーIDを渡す）', async () => {
       mockSettingsService.findOne.mockResolvedValue(mockSettingResponse);
 
-      const result = await controller.findOne('github', 'webhook_secret');
+      const result = await controller.findOne(mockRequest, 'github', 'webhook_secret');
 
       expect(result).toEqual(mockSettingResponse);
-      expect(service.findOne).toHaveBeenCalledWith('github', 'webhook_secret');
+      expect(service.findOne).toHaveBeenCalledWith('github', 'webhook_secret', 'user-1');
     });
 
     it('異なるプロバイダーとタイプで取得できること', async () => {
@@ -141,26 +141,26 @@ describe('SettingsController', () => {
       };
       mockSettingsService.findOne.mockResolvedValue(slackSetting);
 
-      const result = await controller.findOne('slack', 'client_id');
+      const result = await controller.findOne(mockRequest, 'slack', 'client_id');
 
       expect(result).toEqual(slackSetting);
-      expect(service.findOne).toHaveBeenCalledWith('slack', 'client_id');
+      expect(service.findOne).toHaveBeenCalledWith('slack', 'client_id', 'user-1');
     });
   });
 
   describe('remove', () => {
-    it('設定を削除できること', async () => {
+    it('設定を削除できること（ユーザーIDを渡す）', async () => {
       mockSettingsService.remove.mockResolvedValue(undefined);
 
-      await controller.remove('github', 'webhook_secret');
+      await controller.remove(mockRequest, 'github', 'webhook_secret');
 
-      expect(service.remove).toHaveBeenCalledWith('github', 'webhook_secret');
+      expect(service.remove).toHaveBeenCalledWith('github', 'webhook_secret', 'user-1');
     });
 
     it('削除時に値を返さないこと', async () => {
       mockSettingsService.remove.mockResolvedValue(undefined);
 
-      const result = await controller.remove('github', 'webhook_secret');
+      const result = await controller.remove(mockRequest, 'github', 'webhook_secret');
 
       expect(result).toBeUndefined();
     });

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -22,11 +22,11 @@ export class SettingsController {
 
   /**
    * 設定を作成または更新する
-   * グローバル設定（webhook_secret等）はuserId=nullで保存
+   * 認証ユーザーのIDに紐付けて保存
    */
   @Post()
   async upsert(@Request() req, @Body() dto: CreateSettingDto): Promise<SettingResponse> {
-    return this.settingsService.upsert(dto);
+    return this.settingsService.upsert(dto, req.user.id);
   }
 
   /**
@@ -43,10 +43,11 @@ export class SettingsController {
    */
   @Get(':provider/:settingType')
   async findOne(
+    @Request() req,
     @Param('provider') provider: string,
     @Param('settingType') settingType: string,
   ): Promise<SettingResponse> {
-    return this.settingsService.findOne(provider, settingType);
+    return this.settingsService.findOne(provider, settingType, req.user.id);
   }
 
   /**
@@ -55,9 +56,10 @@ export class SettingsController {
   @Delete(':provider/:settingType')
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(
+    @Request() req,
     @Param('provider') provider: string,
     @Param('settingType') settingType: string,
   ): Promise<void> {
-    await this.settingsService.remove(provider, settingType);
+    await this.settingsService.remove(provider, settingType, req.user.id);
   }
 }

--- a/apps/api/src/settings/settings.service.spec.ts
+++ b/apps/api/src/settings/settings.service.spec.ts
@@ -182,13 +182,13 @@ describe('SettingsService', () => {
       });
     });
 
-    it('userId指定時はユーザー別+グローバル設定を返すこと', async () => {
+    it('userId指定時はそのユーザーの設定のみ返すこと', async () => {
       mockPrismaService.settings.findMany.mockResolvedValue(mockSettings);
 
       await service.findAll(undefined, 'user-1');
 
       expect(prisma.settings.findMany).toHaveBeenCalledWith({
-        where: { OR: [{ userId: 'user-1' }, { userId: null }] },
+        where: { userId: 'user-1' },
         orderBy: [{ provider: 'asc' }, { settingType: 'asc' }],
       });
     });
@@ -201,7 +201,7 @@ describe('SettingsService', () => {
       expect(prisma.settings.findMany).toHaveBeenCalledWith({
         where: {
           provider: 'slack',
-          OR: [{ userId: 'user-1' }, { userId: null }],
+          userId: 'user-1',
         },
         orderBy: [{ provider: 'asc' }, { settingType: 'asc' }],
       });

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -56,7 +56,7 @@ export class SettingsService {
   /**
    * 全ての設定を取得する（値は非表示）
    * @param provider プロバイダーでフィルタ
-   * @param userId ユーザーID（指定時はそのユーザーの設定+グローバル設定を返す）
+   * @param userId ユーザーID（指定時はそのユーザーの設定のみ返す）
    */
   async findAll(provider?: string, userId?: string | null): Promise<SettingResponse[]> {
     const where: Record<string, unknown> = {};
@@ -64,8 +64,7 @@ export class SettingsService {
       where.provider = provider;
     }
     if (userId) {
-      // ユーザー別設定とグローバル設定（userId=NULL）の両方を返す
-      where.OR = [{ userId }, { userId: null }];
+      where.userId = userId;
     }
 
     const settings = await this.prisma.settings.findMany({


### PR DESCRIPTION
## Summary

- SettingsController の `upsert()`, `findOne()`, `remove()` に `req.user.id` を渡すように修正
- `findAll` のグローバル設定フォールバック（`OR: [{ userId }, { userId: null }]`）を除去し、ユーザー自身の設定のみ返すように変更
- 既存の `userId=null` 設定を正しいユーザーに紐付けるデータマイグレーションを追加

Closes #110

## Test plan

- [x] `settings.controller.spec.ts` - 全9テスト通過（userId が正しく渡されることを検証）
- [x] `settings.service.spec.ts` - 全15テスト通過（グローバルフォールバック除去に対応）
- [ ] デプロイ後: 別アカウントでログインし、GitHub/Slack設定が見えないことを確認
- [ ] マイグレーション実行後: 既存ユーザーの設定が正しく紐付いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)