### PR TITLE
feat: Factsページに日付フィルタ機能を追加

### DIFF
--- a/apps/web/src/app/facts/page.tsx
+++ b/apps/web/src/app/facts/page.tsx
@@ -18,10 +18,12 @@ import {
   Icon,
 } from '@chakra-ui/react';
 import { MainLayout } from '@/components/layout';
+import { DateFilter } from '@/components/facts';
 import { FiSearch, FiExternalLink, FiRefreshCw } from 'react-icons/fi';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, Suspense } from 'react';
 import apiClient from '@/lib/axios';
 import { formatRelativeTime } from '@/lib/formatRelativeTime';
+import { useDateFilter } from '@/hooks/useDateFilter';
 
 interface Fact {
   id: string;
@@ -71,40 +73,56 @@ function formatDate(dateString: string): string {
 // ポーリング間隔（30秒）
 const POLLING_INTERVAL = 30000;
 
-export default function FactsPage() {
+function FactsPageContent() {
   const [facts, setFacts] = useState<Fact[]>([]);
   const [loading, setLoading] = useState(true);
   const [isBackgroundUpdate, setIsBackgroundUpdate] = useState(false);
   const [sourceFilter, setSourceFilter] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
 
-  const fetchFacts = async (isBackground = false) => {
-    if (!isBackground) {
-      setLoading(true);
-    } else {
-      setIsBackgroundUpdate(true);
-    }
+  const {
+    from,
+    to,
+    preset,
+    isActive: dateFilterActive,
+    setDateRange,
+    applyPreset,
+    clearFilter,
+    apiParams,
+  } = useDateFilter();
 
-    try {
-      const params = new URLSearchParams();
-      if (sourceFilter) params.append('source', sourceFilter);
+  const fetchFacts = useCallback(
+    async (isBackground = false) => {
+      if (!isBackground) {
+        setLoading(true);
+      } else {
+        setIsBackgroundUpdate(true);
+      }
 
-      const response = await apiClient.get<FactsResponse>(
-        `/api/facts?${params.toString()}`
-      );
-      setFacts(response.data.data);
-    } catch (error) {
-      console.error('Failed to fetch facts:', error);
-    } finally {
-      setLoading(false);
-      setIsBackgroundUpdate(false);
-    }
-  };
+      try {
+        const params = new URLSearchParams();
+        if (sourceFilter) params.append('source', sourceFilter);
+        if (apiParams.from) params.append('from', apiParams.from);
+        if (apiParams.to) params.append('to', apiParams.to);
+
+        const response = await apiClient.get<FactsResponse>(
+          `/api/facts?${params.toString()}`,
+        );
+        setFacts(response.data.data);
+      } catch (error) {
+        console.error('Failed to fetch facts:', error);
+      } finally {
+        setLoading(false);
+        setIsBackgroundUpdate(false);
+      }
+    },
+    [sourceFilter, apiParams.from, apiParams.to],
+  );
 
   // 初回ロードとフィルター変更時のフェッチ
   useEffect(() => {
     fetchFacts();
-  }, [sourceFilter]);
+  }, [fetchFacts]);
 
   // 30秒ごとのポーリング
   useEffect(() => {
@@ -112,11 +130,10 @@ export default function FactsPage() {
       fetchFacts(true);
     }, POLLING_INTERVAL);
 
-    // クリーンアップ
     return () => {
       clearInterval(intervalId);
     };
-  }, [sourceFilter]);
+  }, [fetchFacts]);
 
   const filteredFacts = facts.filter((fact) => {
     if (!searchQuery) return true;
@@ -132,44 +149,60 @@ export default function FactsPage() {
       {/* Filters */}
       <Card bg="gray.800" borderColor="gray.700" borderWidth="1px" mb={6}>
         <CardBody>
-          <Flex gap={4} flexWrap="wrap">
-            <InputGroup maxW="300px">
-              <InputLeftElement pointerEvents="none">
-                <FiSearch color="gray" />
-              </InputLeftElement>
-              <Input
-                placeholder="検索..."
+          <VStack spacing={4} align="stretch">
+            <Flex gap={4} flexWrap="wrap">
+              <InputGroup maxW="300px">
+                <InputLeftElement pointerEvents="none">
+                  <FiSearch color="gray" />
+                </InputLeftElement>
+                <Input
+                  placeholder="検索..."
+                  bg="gray.900"
+                  border="none"
+                  _placeholder={{ color: 'gray.500' }}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </InputGroup>
+
+              <Select
+                maxW="200px"
                 bg="gray.900"
-                border="none"
-                _placeholder={{ color: 'gray.500' }}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            </InputGroup>
+                borderColor="gray.700"
+                value={sourceFilter}
+                onChange={(e) => setSourceFilter(e.target.value)}
+              >
+                <option value="">すべてのソース</option>
+                <option value="github">GitHub</option>
+                <option value="slack">Slack</option>
+                <option value="manual">Manual</option>
+              </Select>
 
-            <Select
-              maxW="200px"
-              bg="gray.900"
-              borderColor="gray.700"
-              value={sourceFilter}
-              onChange={(e) => setSourceFilter(e.target.value)}
-            >
-              <option value="">すべてのソース</option>
-              <option value="github">GitHub</option>
-              <option value="slack">Slack</option>
-              <option value="manual">Manual</option>
-            </Select>
+              <Button
+                leftIcon={
+                  <FiRefreshCw
+                    className={isBackgroundUpdate ? 'animate-spin' : ''}
+                  />
+                }
+                variant="outline"
+                colorScheme="gray"
+                onClick={() => fetchFacts(false)}
+                isLoading={loading}
+              >
+                更新
+              </Button>
+            </Flex>
 
-            <Button
-              leftIcon={<FiRefreshCw className={isBackgroundUpdate ? 'animate-spin' : ''} />}
-              variant="outline"
-              colorScheme="gray"
-              onClick={() => fetchFacts(false)}
-              isLoading={loading}
-            >
-              更新
-            </Button>
-          </Flex>
+            <DateFilter
+              from={from}
+              to={to}
+              preset={preset}
+              isActive={dateFilterActive}
+              onPreset={applyPreset}
+              onRangeChange={setDateRange}
+              onClear={clearFilter}
+            />
+          </VStack>
         </CardBody>
       </Card>
 
@@ -227,7 +260,8 @@ export default function FactsPage() {
                           {fact.type}
                         </Badge>
                         <Text fontSize="xs" color="gray.500">
-                          {formatRelativeTime(fact.occurredAt)} ({formatDate(fact.occurredAt)})
+                          {formatRelativeTime(fact.occurredAt)} (
+                          {formatDate(fact.occurredAt)})
                         </Text>
                       </HStack>
                     </Box>
@@ -253,5 +287,21 @@ export default function FactsPage() {
         </VStack>
       )}
     </MainLayout>
+  );
+}
+
+export default function FactsPage() {
+  return (
+    <Suspense
+      fallback={
+        <MainLayout title="Facts" subtitle="収集されたすべてのファクトを表示">
+          <Flex justify="center" py={10}>
+            <Spinner size="xl" color="brand.500" />
+          </Flex>
+        </MainLayout>
+      }
+    >
+      <FactsPageContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/facts/DateFilter.tsx
+++ b/apps/web/src/components/facts/DateFilter.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import {
+  Flex,
+  ButtonGroup,
+  Button,
+  Input,
+  IconButton,
+  Text,
+} from '@chakra-ui/react';
+import { FiX } from 'react-icons/fi';
+import { DatePreset } from '@/lib/dateUtils';
+
+interface DateFilterProps {
+  from: string;
+  to: string;
+  preset: DatePreset | '';
+  isActive: boolean;
+  onPreset: (preset: DatePreset) => void;
+  onRangeChange: (from: string, to: string) => void;
+  onClear: () => void;
+}
+
+const presets: { key: DatePreset; label: string }[] = [
+  { key: 'today', label: '今日' },
+  { key: 'thisWeek', label: '今週' },
+  { key: 'thisMonth', label: '今月' },
+];
+
+export function DateFilter({
+  from,
+  to,
+  preset,
+  isActive,
+  onPreset,
+  onRangeChange,
+  onClear,
+}: DateFilterProps) {
+  return (
+    <Flex
+      gap={3}
+      flexWrap="wrap"
+      alignItems="center"
+      p={3}
+      borderRadius="md"
+      borderWidth="1px"
+      borderColor={isActive ? 'brand.500' : 'gray.700'}
+      bg="gray.900"
+    >
+      <ButtonGroup size="sm" isAttached variant="outline">
+        {presets.map((p) => (
+          <Button
+            key={p.key}
+            onClick={() => onPreset(p.key)}
+            variant={preset === p.key ? 'solid' : 'outline'}
+            colorScheme={preset === p.key ? 'brand' : 'gray'}
+          >
+            {p.label}
+          </Button>
+        ))}
+      </ButtonGroup>
+
+      <Flex alignItems="center" gap={2}>
+        <Input
+          type="date"
+          size="sm"
+          maxW="160px"
+          bg="gray.800"
+          borderColor="gray.600"
+          value={from}
+          onChange={(e) => onRangeChange(e.target.value, to)}
+          sx={{
+            colorScheme: 'dark',
+            '&::-webkit-calendar-picker-indicator': {
+              filter: 'invert(1)',
+            },
+          }}
+        />
+        <Text color="gray.500" fontSize="sm">
+          ~
+        </Text>
+        <Input
+          type="date"
+          size="sm"
+          maxW="160px"
+          bg="gray.800"
+          borderColor="gray.600"
+          value={to}
+          onChange={(e) => onRangeChange(from, e.target.value)}
+          sx={{
+            colorScheme: 'dark',
+            '&::-webkit-calendar-picker-indicator': {
+              filter: 'invert(1)',
+            },
+          }}
+        />
+      </Flex>
+
+      {isActive && (
+        <IconButton
+          aria-label="フィルタをクリア"
+          icon={<FiX />}
+          size="sm"
+          variant="ghost"
+          colorScheme="gray"
+          onClick={onClear}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/apps/web/src/components/facts/index.ts
+++ b/apps/web/src/components/facts/index.ts
@@ -1,0 +1,1 @@
+export { DateFilter } from './DateFilter';

--- a/apps/web/src/hooks/useDateFilter.ts
+++ b/apps/web/src/hooks/useDateFilter.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
+import { DatePreset, getPresetRange, toISOStart, toISOEnd } from '@/lib/dateUtils';
+
+export function useDateFilter() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const from = searchParams.get('from') ?? '';
+  const to = searchParams.get('to') ?? '';
+  const preset = (searchParams.get('preset') ?? '') as DatePreset | '';
+
+  const isActive = from !== '' || to !== '';
+
+  const updateParams = useCallback(
+    (updates: Record<string, string>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) {
+          params.set(key, value);
+        } else {
+          params.delete(key);
+        }
+      }
+      router.replace(`${pathname}?${params.toString()}`);
+    },
+    [searchParams, router, pathname],
+  );
+
+  const setDateRange = useCallback(
+    (newFrom: string, newTo: string) => {
+      updateParams({ from: newFrom, to: newTo, preset: '' });
+    },
+    [updateParams],
+  );
+
+  const applyPreset = useCallback(
+    (p: DatePreset) => {
+      const range = getPresetRange(p);
+      updateParams({ from: range.from, to: range.to, preset: p });
+    },
+    [updateParams],
+  );
+
+  const clearFilter = useCallback(() => {
+    updateParams({ from: '', to: '', preset: '' });
+  }, [updateParams]);
+
+  const apiParams = useMemo(() => {
+    const params: { from?: string; to?: string } = {};
+    if (from) params.from = toISOStart(from);
+    if (to) params.to = toISOEnd(to);
+    return params;
+  }, [from, to]);
+
+  return {
+    from,
+    to,
+    preset,
+    isActive,
+    setDateRange,
+    applyPreset,
+    clearFilter,
+    apiParams,
+  };
+}

--- a/apps/web/src/lib/dateUtils.ts
+++ b/apps/web/src/lib/dateUtils.ts
@@ -1,0 +1,55 @@
+export type DatePreset = 'today' | 'thisWeek' | 'thisMonth';
+
+interface DateRange {
+  from: string; // YYYY-MM-DD
+  to: string; // YYYY-MM-DD
+}
+
+/**
+ * プリセットに対応する日付範囲を返す (YYYY-MM-DD)
+ */
+export function getPresetRange(preset: DatePreset): DateRange {
+  const now = new Date();
+  const to = formatLocalDate(now);
+
+  switch (preset) {
+    case 'today':
+      return { from: to, to };
+    case 'thisWeek': {
+      const day = now.getDay();
+      const diff = day === 0 ? 6 : day - 1; // 月曜始まり
+      const monday = new Date(now);
+      monday.setDate(now.getDate() - diff);
+      return { from: formatLocalDate(monday), to };
+    }
+    case 'thisMonth': {
+      const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
+      return { from: formatLocalDate(firstDay), to };
+    }
+  }
+}
+
+/**
+ * YYYY-MM-DD → ローカル日の開始 (00:00:00) を UTC ISO8601 に変換
+ */
+export function toISOStart(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const date = new Date(year, month - 1, day, 0, 0, 0, 0);
+  return date.toISOString();
+}
+
+/**
+ * YYYY-MM-DD → ローカル日の終了 (23:59:59.999) を UTC ISO8601 に変換
+ */
+export function toISOEnd(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const date = new Date(year, month - 1, day, 23, 59, 59, 999);
+  return date.toISOString();
+}
+
+function formatLocalDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}


### PR DESCRIPTION
## Summary
- Factsページにプリセット（今日/今週/今月）とカスタム日付範囲による日付フィルタ機能を追加
- フィルタ状態をURLパラメータ（`from`, `to`, `preset`）で管理し、リロード・URL共有に対応
- Backend API の既存 `from`/`to` パラメータを活用（フロントエンドのみの変更）

## 変更内容
- `lib/dateUtils.ts`: プリセット計算、ローカル日付→UTC ISO8601変換ユーティリティ
- `hooks/useDateFilter.ts`: URL パラメータ双方向同期カスタムフック
- `components/facts/DateFilter.tsx`: 日付フィルタUIコンポーネント（ダークテーマ・モバイル対応）
- `app/facts/page.tsx`: Suspense boundary追加、フック統合、API呼び出しにfrom/toパラメータ追加

## Test plan
- [x] APIテスト（facts関連28件）パス
- [x] Webビルド成功（TypeScript・ESLintエラーなし）
- [ ] プリセットボタン（今日/今週/今月）クリックでFactsがフィルタされること
- [ ] カスタム日付範囲で正しくフィルタされること
- [ ] URLに `?from=...&to=...` が反映されること
- [ ] リロードでフィルタが維持されること
- [ ] クリアボタンでフィルタ解除されること
- [ ] モバイル表示でレイアウトが崩れないこと

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)