### PR TITLE
feat: GitHub複数リポジトリ対応

### DIFF
--- a/apps/api/prisma/migrations/20260215100000_add_repositories/migration.sql
+++ b/apps/api/prisma/migrations/20260215100000_add_repositories/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS factrail.repositories (
+    id TEXT NOT NULL,
+    integration_id TEXT NOT NULL,
+    full_name TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    name TEXT NOT NULL,
+    is_private BOOLEAN NOT NULL DEFAULT false,
+    status TEXT NOT NULL DEFAULT 'active',
+    last_event_at TIMESTAMP(3),
+    created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT repositories_pkey PRIMARY KEY (id)
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS repositories_integration_id_full_name_key ON factrail.repositories(integration_id, full_name);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS repositories_full_name_idx ON factrail.repositories(full_name);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS repositories_owner_idx ON factrail.repositories(owner);
+
+-- AddForeignKey
+DO $$ BEGIN
+  ALTER TABLE factrail.repositories ADD CONSTRAINT repositories_integration_id_fkey
+    FOREIGN KEY (integration_id) REFERENCES factrail.integrations(id) ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,12 +60,36 @@ model Integration {
   userId String @map("user_id")
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  repositories Repository[]
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@unique([provider, accountId])
   @@index([userId])
   @@map("integrations")
+  @@schema("factrail")
+}
+
+model Repository {
+  id            String      @id @default(uuid())
+  integrationId String      @map("integration_id")
+  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+
+  fullName  String  @map("full_name")
+  owner     String
+  name      String
+  isPrivate Boolean @default(false) @map("is_private")
+  status    String  @default("active")
+
+  lastEventAt DateTime? @map("last_event_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+
+  @@unique([integrationId, fullName])
+  @@index([fullName])
+  @@index([owner])
+  @@map("repositories")
   @@schema("factrail")
 }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,7 @@ import { CryptoModule } from './common/crypto';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { SettingsModule } from './settings/settings.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
+import { RepositoriesModule } from './repositories/repositories.module';
 import { DispatchersModule } from './dispatchers/dispatchers.module';
 
 @Module({
@@ -62,6 +63,7 @@ import { DispatchersModule } from './dispatchers/dispatchers.module';
     FactsModule,
     HealthModule,
     IntegrationsModule,
+    RepositoriesModule,
     SettingsModule,
     WebhooksModule,
   ],

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -154,7 +154,9 @@ describe('AuthController', () => {
       });
       expect(authService.createAuthCode).toHaveBeenCalledWith(mockLoginData);
       // ワンタイム認証コード付きでリダイレクト
-      expect(mockResponse.redirect).toHaveBeenCalledWith(`http://localhost:3000/auth/callback?code=${mockAuthCode}`);
+      expect(mockResponse.redirect).toHaveBeenCalledWith(
+        `http://localhost:3000/auth/callback?code=${mockAuthCode}`,
+      );
     });
 
     it('user-agentヘッダーなしでGoogle OAuthコールバックを処理すること', async () => {
@@ -178,7 +180,9 @@ describe('AuthController', () => {
         ip: '10.0.0.1',
       });
       expect(authService.createAuthCode).toHaveBeenCalledWith(mockLoginData);
-      expect(mockResponse.redirect).toHaveBeenCalledWith(`http://localhost:3000/auth/callback?code=${mockAuthCode}`);
+      expect(mockResponse.redirect).toHaveBeenCalledWith(
+        `http://localhost:3000/auth/callback?code=${mockAuthCode}`,
+      );
     });
   });
 
@@ -193,7 +197,7 @@ describe('AuthController', () => {
   describe('githubAuthCallback', () => {
     it('GitHub OAuthコールバックを処理してリダイレクトすること', async () => {
       const mockRequest = {
-        user: { ...mockUser, githubUsername: 'testuser' },
+        user: { ...mockUser, githubUsername: 'testuser', githubAccessToken: 'gh-access-token-123' },
         ip: '127.0.0.1',
       } as unknown as Request;
       const mockResponse = {
@@ -209,7 +213,7 @@ describe('AuthController', () => {
       await controller.githubAuthCallback(mockRequest, mockResponse, userAgent);
 
       expect(authService.login).toHaveBeenCalledWith(
-        { ...mockUser, githubUsername: 'testuser' },
+        { ...mockUser, githubUsername: 'testuser', githubAccessToken: 'gh-access-token-123' },
         {
           userAgent,
           ip: '127.0.0.1',
@@ -219,12 +223,14 @@ describe('AuthController', () => {
         provider: 'github',
         accountId: 'testuser',
         accountName: 'testuser',
-        accessToken: 'oauth-login',
-        scope: ['user:email'],
+        accessToken: 'gh-access-token-123',
+        scope: ['user:email', 'read:user', 'repo'],
       });
       expect(authService.createAuthCode).toHaveBeenCalledWith(mockLoginData);
       // ワンタイム認証コード付きでリダイレクト
-      expect(mockResponse.redirect).toHaveBeenCalledWith(`http://localhost:3000/auth/callback?code=${mockAuthCode}`);
+      expect(mockResponse.redirect).toHaveBeenCalledWith(
+        `http://localhost:3000/auth/callback?code=${mockAuthCode}`,
+      );
     });
 
     it('user-agentヘッダーなしでGitHub OAuthコールバックを処理すること', async () => {
@@ -248,7 +254,9 @@ describe('AuthController', () => {
         ip: '172.16.0.1',
       });
       expect(authService.createAuthCode).toHaveBeenCalledWith(mockLoginData);
-      expect(mockResponse.redirect).toHaveBeenCalledWith(`http://localhost:3000/auth/callback?code=${mockAuthCode}`);
+      expect(mockResponse.redirect).toHaveBeenCalledWith(
+        `http://localhost:3000/auth/callback?code=${mockAuthCode}`,
+      );
     });
   });
 

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -136,8 +136,8 @@ export class AuthController {
         provider: 'github',
         accountId: user.githubUsername,
         accountName: user.githubUsername,
-        accessToken: 'oauth-login', // OAuthログイン用のプレースホルダー
-        scope: ['user:email'],
+        accessToken: user.githubAccessToken,
+        scope: ['user:email', 'read:user', 'repo'],
       });
     }
 

--- a/apps/api/src/auth/strategies/github.strategy.ts
+++ b/apps/api/src/auth/strategies/github.strategy.ts
@@ -14,7 +14,7 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
       clientID: configService.get('GITHUB_CLIENT_ID'),
       clientSecret: configService.get('GITHUB_CLIENT_SECRET'),
       callbackURL: configService.get('GITHUB_CALLBACK_URL'),
-      scope: ['user:email'],
+      scope: ['user:email', 'read:user', 'repo'],
     });
   }
 
@@ -26,6 +26,6 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
       name: profile.displayName || profile.username,
       avatar: profile.photos[0]?.value,
     });
-    return { ...user, githubUsername: profile.username };
+    return { ...user, githubUsername: profile.username, githubAccessToken: accessToken };
   }
 }

--- a/apps/api/src/repositories/dto/add-repository.dto.ts
+++ b/apps/api/src/repositories/dto/add-repository.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class AddRepositoryDto {
+  @IsString()
+  @IsNotEmpty()
+  fullName: string;
+}

--- a/apps/api/src/repositories/github-api.service.spec.ts
+++ b/apps/api/src/repositories/github-api.service.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { GitHubApiService } from './github-api.service';
+
+describe('GitHubApiService', () => {
+  let service: GitHubApiService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GitHubApiService],
+    }).compile();
+
+    service = module.get<GitHubApiService>(GitHubApiService);
+
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('listRepositories', () => {
+    it('GitHub APIからリポジトリ一覧を取得できること', async () => {
+      const mockRepos = [
+        {
+          full_name: 'test/repo1',
+          name: 'repo1',
+          owner: { login: 'test' },
+          private: false,
+          html_url: 'https://github.com/test/repo1',
+        },
+        {
+          full_name: 'test/repo2',
+          name: 'repo2',
+          owner: { login: 'test' },
+          private: true,
+          html_url: 'https://github.com/test/repo2',
+        },
+      ];
+
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockRepos,
+      } as Response);
+
+      const result = await service.listRepositories('test-token');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        fullName: 'test/repo1',
+        name: 'repo1',
+        owner: 'test',
+        isPrivate: false,
+        htmlUrl: 'https://github.com/test/repo1',
+      });
+      expect(result[1].isPrivate).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('https://api.github.com/user/repos'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('APIエラー時に例外をスローすること', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      } as Response);
+
+      await expect(service.listRepositories('invalid-token')).rejects.toThrow(
+        'GitHub APIリクエストに失敗しました: 401',
+      );
+    });
+  });
+
+  describe('getRepository', () => {
+    it('リポジトリ情報を取得できること', async () => {
+      const mockRepo = {
+        full_name: 'test/repo1',
+        name: 'repo1',
+        owner: { login: 'test' },
+        private: false,
+        html_url: 'https://github.com/test/repo1',
+      };
+
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockRepo,
+      } as Response);
+
+      const result = await service.getRepository('test-token', 'test/repo1');
+
+      expect(result).toEqual({
+        fullName: 'test/repo1',
+        name: 'repo1',
+        owner: 'test',
+        isPrivate: false,
+        htmlUrl: 'https://github.com/test/repo1',
+      });
+    });
+
+    it('リポジトリが存在しない場合はnullを返すこと', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      } as Response);
+
+      const result = await service.getRepository('test-token', 'test/nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('APIエラー時に例外をスローすること', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      } as Response);
+
+      await expect(service.getRepository('test-token', 'test/repo1')).rejects.toThrow(
+        'GitHub APIリクエストに失敗しました: 500',
+      );
+    });
+  });
+});

--- a/apps/api/src/repositories/github-api.service.ts
+++ b/apps/api/src/repositories/github-api.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+interface GitHubRepo {
+  full_name: string;
+  name: string;
+  owner: { login: string };
+  private: boolean;
+  html_url: string;
+}
+
+export interface GitHubRepoInfo {
+  fullName: string;
+  name: string;
+  owner: string;
+  isPrivate: boolean;
+  htmlUrl: string;
+}
+
+@Injectable()
+export class GitHubApiService {
+  private readonly logger = new Logger(GitHubApiService.name);
+
+  async listRepositories(accessToken: string): Promise<GitHubRepoInfo[]> {
+    const repos: GitHubRepoInfo[] = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const response = await fetch(
+        `https://api.github.com/user/repos?per_page=${perPage}&page=${page}&sort=updated&direction=desc`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/vnd.github+json',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        this.logger.error(`GitHub API error: ${response.status} ${response.statusText}`);
+        throw new Error(`GitHub APIリクエストに失敗しました: ${response.status}`);
+      }
+
+      const data: GitHubRepo[] = await response.json();
+
+      for (const repo of data) {
+        repos.push({
+          fullName: repo.full_name,
+          name: repo.name,
+          owner: repo.owner.login,
+          isPrivate: repo.private,
+          htmlUrl: repo.html_url,
+        });
+      }
+
+      if (data.length < perPage) {
+        break;
+      }
+
+      page++;
+    }
+
+    return repos;
+  }
+
+  async getRepository(accessToken: string, fullName: string): Promise<GitHubRepoInfo | null> {
+    const response = await fetch(`https://api.github.com/repos/${fullName}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      this.logger.error(`GitHub API error: ${response.status} ${response.statusText}`);
+      throw new Error(`GitHub APIリクエストに失敗しました: ${response.status}`);
+    }
+
+    const repo: GitHubRepo = await response.json();
+
+    return {
+      fullName: repo.full_name,
+      name: repo.name,
+      owner: repo.owner.login,
+      isPrivate: repo.private,
+      htmlUrl: repo.html_url,
+    };
+  }
+}

--- a/apps/api/src/repositories/repositories.controller.spec.ts
+++ b/apps/api/src/repositories/repositories.controller.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RepositoriesController } from './repositories.controller';
+import { RepositoriesService } from './repositories.service';
+
+describe('RepositoriesController', () => {
+  let controller: RepositoriesController;
+  let service: RepositoriesService;
+
+  const mockRepositoriesService = {
+    findAll: jest.fn(),
+    getAvailableRepositories: jest.fn(),
+    add: jest.fn(),
+    remove: jest.fn(),
+    detectFromFacts: jest.fn(),
+  };
+
+  const mockRequest = {
+    user: {
+      id: 'user-123',
+      email: 'test@example.com',
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RepositoriesController],
+      providers: [
+        {
+          provide: RepositoriesService,
+          useValue: mockRepositoriesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<RepositoriesController>(RepositoriesController);
+    service = module.get<RepositoriesService>(RepositoriesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('登録済みリポジトリ一覧を取得できること', async () => {
+      const mockRepos = [
+        {
+          id: 'repo-1',
+          fullName: 'test/repo1',
+          owner: 'test',
+          name: 'repo1',
+          isPrivate: false,
+          status: 'active',
+        },
+      ];
+      mockRepositoriesService.findAll.mockResolvedValue(mockRepos);
+
+      const result = await controller.findAll(mockRequest);
+
+      expect(result).toEqual(mockRepos);
+      expect(service.findAll).toHaveBeenCalledWith('user-123');
+    });
+  });
+
+  describe('getAvailable', () => {
+    it('GitHub APIからリポジトリ候補を取得できること', async () => {
+      const mockAvailable = [
+        {
+          fullName: 'test/repo1',
+          name: 'repo1',
+          owner: 'test',
+          isPrivate: false,
+          htmlUrl: 'https://github.com/test/repo1',
+        },
+      ];
+      mockRepositoriesService.getAvailableRepositories.mockResolvedValue(mockAvailable);
+
+      const result = await controller.getAvailable(mockRequest);
+
+      expect(result).toEqual(mockAvailable);
+      expect(service.getAvailableRepositories).toHaveBeenCalledWith('user-123');
+    });
+  });
+
+  describe('add', () => {
+    it('リポジトリを追加できること', async () => {
+      const mockRepo = {
+        id: 'repo-1',
+        fullName: 'test/repo1',
+        owner: 'test',
+        name: 'repo1',
+        isPrivate: false,
+        status: 'active',
+      };
+      mockRepositoriesService.add.mockResolvedValue(mockRepo);
+
+      const result = await controller.add(mockRequest, { fullName: 'test/repo1' });
+
+      expect(result).toEqual(mockRepo);
+      expect(service.add).toHaveBeenCalledWith('user-123', 'test/repo1');
+    });
+  });
+
+  describe('remove', () => {
+    it('リポジトリを削除できること', async () => {
+      mockRepositoriesService.remove.mockResolvedValue(undefined);
+
+      await controller.remove(mockRequest, 'repo-1');
+
+      expect(service.remove).toHaveBeenCalledWith('user-123', 'repo-1');
+    });
+  });
+
+  describe('detect', () => {
+    it('既存Factsからリポジトリを自動検出できること', async () => {
+      const mockResult = { added: ['test/repo1', 'test/repo2'] };
+      mockRepositoriesService.detectFromFacts.mockResolvedValue(mockResult);
+
+      const result = await controller.detect(mockRequest);
+
+      expect(result).toEqual(mockResult);
+      expect(service.detectFromFacts).toHaveBeenCalledWith('user-123');
+    });
+  });
+});

--- a/apps/api/src/repositories/repositories.controller.ts
+++ b/apps/api/src/repositories/repositories.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { RepositoriesService } from './repositories.service';
+import { AddRepositoryDto } from './dto/add-repository.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('repositories')
+@UseGuards(JwtAuthGuard)
+export class RepositoriesController {
+  constructor(private readonly repositoriesService: RepositoriesService) {}
+
+  @Get()
+  findAll(@Request() req) {
+    return this.repositoriesService.findAll(req.user.id);
+  }
+
+  @Get('github/available')
+  getAvailable(@Request() req) {
+    return this.repositoriesService.getAvailableRepositories(req.user.id);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  add(@Request() req, @Body() dto: AddRepositoryDto) {
+    return this.repositoriesService.add(req.user.id, dto.fullName);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
+    return this.repositoriesService.remove(req.user.id, id);
+  }
+
+  @Post('detect')
+  detect(@Request() req) {
+    return this.repositoriesService.detectFromFacts(req.user.id);
+  }
+}

--- a/apps/api/src/repositories/repositories.module.ts
+++ b/apps/api/src/repositories/repositories.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { RepositoriesController } from './repositories.controller';
+import { RepositoriesService } from './repositories.service';
+import { GitHubApiService } from './github-api.service';
+import { IntegrationsModule } from '../integrations/integrations.module';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  imports: [IntegrationsModule],
+  controllers: [RepositoriesController],
+  providers: [RepositoriesService, GitHubApiService, PrismaService],
+  exports: [RepositoriesService],
+})
+export class RepositoriesModule {}

--- a/apps/api/src/repositories/repositories.service.spec.ts
+++ b/apps/api/src/repositories/repositories.service.spec.ts
@@ -1,0 +1,263 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { RepositoriesService } from './repositories.service';
+import { PrismaService } from '../prisma.service';
+import { IntegrationsService } from '../integrations/integrations.service';
+import { GitHubApiService } from './github-api.service';
+
+describe('RepositoriesService', () => {
+  let service: RepositoriesService;
+
+  const mockPrismaService = {
+    repository: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    fact: {
+      findMany: jest.fn(),
+    },
+  };
+
+  const mockIntegrationsService = {
+    findByProvider: jest.fn(),
+  };
+
+  const mockGitHubApiService = {
+    listRepositories: jest.fn(),
+    getRepository: jest.fn(),
+  };
+
+  const userId = 'user-123';
+  const mockIntegration = {
+    id: 'int-1',
+    userId,
+    provider: 'github',
+    accountId: 'testuser',
+    accountName: 'testuser',
+    accessToken: 'test-token',
+    refreshToken: null,
+    expiresAt: null,
+    scope: ['repo'],
+    status: 'active',
+    lastSyncAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RepositoriesService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+        {
+          provide: IntegrationsService,
+          useValue: mockIntegrationsService,
+        },
+        {
+          provide: GitHubApiService,
+          useValue: mockGitHubApiService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RepositoriesService>(RepositoriesService);
+
+    // デフォルトでIntegrationが見つかるようにする
+    mockIntegrationsService.findByProvider.mockResolvedValue([mockIntegration]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('登録済みリポジトリ一覧を取得できること', async () => {
+      const mockRepos = [
+        {
+          id: 'repo-1',
+          integrationId: 'int-1',
+          fullName: 'testuser/repo1',
+          owner: 'testuser',
+          name: 'repo1',
+          isPrivate: false,
+          status: 'active',
+          lastEventAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      mockPrismaService.repository.findMany.mockResolvedValue(mockRepos);
+
+      const result = await service.findAll(userId);
+
+      expect(result).toEqual(mockRepos);
+      expect(mockPrismaService.repository.findMany).toHaveBeenCalledWith({
+        where: { integrationId: 'int-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('GitHub連携がない場合はNotFoundExceptionをスローすること', async () => {
+      mockIntegrationsService.findByProvider.mockResolvedValue([]);
+
+      await expect(service.findAll(userId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getAvailableRepositories', () => {
+    it('GitHub APIからリポジトリ候補を取得できること', async () => {
+      const mockGitHubRepos = [
+        {
+          fullName: 'testuser/repo1',
+          name: 'repo1',
+          owner: 'testuser',
+          isPrivate: false,
+          htmlUrl: 'https://github.com/testuser/repo1',
+        },
+        {
+          fullName: 'testuser/repo2',
+          name: 'repo2',
+          owner: 'testuser',
+          isPrivate: true,
+          htmlUrl: 'https://github.com/testuser/repo2',
+        },
+      ];
+      mockGitHubApiService.listRepositories.mockResolvedValue(mockGitHubRepos);
+
+      const result = await service.getAvailableRepositories(userId);
+
+      expect(result).toEqual(mockGitHubRepos);
+      expect(mockGitHubApiService.listRepositories).toHaveBeenCalledWith('test-token');
+    });
+  });
+
+  describe('add', () => {
+    it('リポジトリを追加できること', async () => {
+      const repoInfo = {
+        fullName: 'testuser/repo1',
+        name: 'repo1',
+        owner: 'testuser',
+        isPrivate: false,
+        htmlUrl: 'https://github.com/testuser/repo1',
+      };
+      mockGitHubApiService.getRepository.mockResolvedValue(repoInfo);
+      mockPrismaService.repository.findUnique.mockResolvedValue(null);
+
+      const createdRepo = {
+        id: 'repo-1',
+        integrationId: 'int-1',
+        fullName: 'testuser/repo1',
+        owner: 'testuser',
+        name: 'repo1',
+        isPrivate: false,
+        status: 'active',
+        lastEventAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaService.repository.create.mockResolvedValue(createdRepo);
+
+      const result = await service.add(userId, 'testuser/repo1');
+
+      expect(result).toEqual(createdRepo);
+      expect(mockGitHubApiService.getRepository).toHaveBeenCalledWith(
+        'test-token',
+        'testuser/repo1',
+      );
+    });
+
+    it('GitHubにリポジトリが存在しない場合はNotFoundExceptionをスローすること', async () => {
+      mockGitHubApiService.getRepository.mockResolvedValue(null);
+
+      await expect(service.add(userId, 'testuser/nonexistent')).rejects.toThrow(NotFoundException);
+    });
+
+    it('既に登録済みの場合はBadRequestExceptionをスローすること', async () => {
+      const repoInfo = {
+        fullName: 'testuser/repo1',
+        name: 'repo1',
+        owner: 'testuser',
+        isPrivate: false,
+        htmlUrl: 'https://github.com/testuser/repo1',
+      };
+      mockGitHubApiService.getRepository.mockResolvedValue(repoInfo);
+      mockPrismaService.repository.findUnique.mockResolvedValue({ id: 'existing' });
+
+      await expect(service.add(userId, 'testuser/repo1')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('リポジトリを削除できること', async () => {
+      const mockRepo = {
+        id: 'repo-1',
+        integrationId: 'int-1',
+        fullName: 'testuser/repo1',
+      };
+      mockPrismaService.repository.findFirst.mockResolvedValue(mockRepo);
+      mockPrismaService.repository.delete.mockResolvedValue(mockRepo);
+
+      await service.remove(userId, 'repo-1');
+
+      expect(mockPrismaService.repository.delete).toHaveBeenCalledWith({
+        where: { id: 'repo-1' },
+      });
+    });
+
+    it('リポジトリが見つからない場合はNotFoundExceptionをスローすること', async () => {
+      mockPrismaService.repository.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove(userId, 'repo-nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('detectFromFacts', () => {
+    it('既存Factsからリポジトリを自動検出して登録できること', async () => {
+      const mockFacts = [
+        { metadata: { repository: 'testuser/repo1' } },
+        { metadata: { repository: 'testuser/repo2' } },
+        { metadata: { repository: 'testuser/repo1' } }, // 重複
+      ];
+      mockPrismaService.fact.findMany.mockResolvedValue(mockFacts);
+      mockPrismaService.repository.findUnique.mockResolvedValue(null);
+      mockGitHubApiService.getRepository.mockResolvedValue({
+        fullName: 'testuser/repo1',
+        name: 'repo1',
+        owner: 'testuser',
+        isPrivate: false,
+      });
+      mockPrismaService.repository.create.mockResolvedValue({});
+
+      const result = await service.detectFromFacts(userId);
+
+      expect(result.added).toHaveLength(2);
+      expect(result.added).toContain('testuser/repo1');
+      expect(result.added).toContain('testuser/repo2');
+    });
+
+    it('既に登録済みのリポジトリはスキップすること', async () => {
+      const mockFacts = [{ metadata: { repository: 'testuser/repo1' } }];
+      mockPrismaService.fact.findMany.mockResolvedValue(mockFacts);
+      mockPrismaService.repository.findUnique.mockResolvedValue({ id: 'existing' });
+
+      const result = await service.detectFromFacts(userId);
+
+      expect(result.added).toHaveLength(0);
+      expect(mockPrismaService.repository.create).not.toHaveBeenCalled();
+    });
+
+    it('Factsがない場合は空の結果を返すこと', async () => {
+      mockPrismaService.fact.findMany.mockResolvedValue([]);
+
+      const result = await service.detectFromFacts(userId);
+
+      expect(result.added).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/repositories/repositories.service.ts
+++ b/apps/api/src/repositories/repositories.service.ts
@@ -1,0 +1,189 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { IntegrationsService } from '../integrations/integrations.service';
+import { GitHubApiService, GitHubRepoInfo } from './github-api.service';
+
+@Injectable()
+export class RepositoriesService {
+  private readonly logger = new Logger(RepositoriesService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly integrationsService: IntegrationsService,
+    private readonly githubApiService: GitHubApiService,
+  ) {}
+
+  /**
+   * ユーザーのGitHub Integrationを取得する
+   */
+  private async getGitHubIntegration(userId: string) {
+    const integrations = await this.integrationsService.findByProvider(userId, 'github');
+    if (integrations.length === 0) {
+      throw new NotFoundException('GitHub連携が見つかりません');
+    }
+    return integrations[0];
+  }
+
+  /**
+   * 登録済みリポジトリ一覧を取得する
+   */
+  async findAll(userId: string) {
+    const integration = await this.getGitHubIntegration(userId);
+
+    return this.prisma.repository.findMany({
+      where: { integrationId: integration.id },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * GitHub APIからリポジトリ候補を取得する
+   */
+  async getAvailableRepositories(userId: string): Promise<GitHubRepoInfo[]> {
+    const integration = await this.getGitHubIntegration(userId);
+    return this.githubApiService.listRepositories(integration.accessToken);
+  }
+
+  /**
+   * リポジトリを追加する
+   */
+  async add(userId: string, fullName: string) {
+    const integration = await this.getGitHubIntegration(userId);
+
+    // GitHub APIでリポジトリ情報を取得
+    const repoInfo = await this.githubApiService.getRepository(integration.accessToken, fullName);
+    if (!repoInfo) {
+      throw new NotFoundException(`リポジトリが見つかりません: ${fullName}`);
+    }
+
+    // 重複チェック
+    const existing = await this.prisma.repository.findUnique({
+      where: {
+        integrationId_fullName: {
+          integrationId: integration.id,
+          fullName: repoInfo.fullName,
+        },
+      },
+    });
+
+    if (existing) {
+      throw new BadRequestException(`リポジトリは既に登録されています: ${fullName}`);
+    }
+
+    return this.prisma.repository.create({
+      data: {
+        integrationId: integration.id,
+        fullName: repoInfo.fullName,
+        owner: repoInfo.owner,
+        name: repoInfo.name,
+        isPrivate: repoInfo.isPrivate,
+      },
+    });
+  }
+
+  /**
+   * リポジトリを削除する
+   */
+  async remove(userId: string, id: string) {
+    const integration = await this.getGitHubIntegration(userId);
+
+    const repository = await this.prisma.repository.findFirst({
+      where: {
+        id,
+        integrationId: integration.id,
+      },
+    });
+
+    if (!repository) {
+      throw new NotFoundException(`リポジトリが見つかりません: ID ${id}`);
+    }
+
+    await this.prisma.repository.delete({
+      where: { id },
+    });
+  }
+
+  /**
+   * 既存Factsからリポジトリを自動検出して登録する
+   */
+  async detectFromFacts(userId: string) {
+    const integration = await this.getGitHubIntegration(userId);
+
+    // GitHubソースのFactsからユニークなリポジトリ名を取得
+    const facts = await this.prisma.fact.findMany({
+      where: {
+        userId,
+        source: 'github',
+      },
+      select: {
+        metadata: true,
+      },
+    });
+
+    const repoNames = new Set<string>();
+    for (const fact of facts) {
+      const metadata = fact.metadata as Record<string, unknown> | null;
+      if (metadata?.repository && typeof metadata.repository === 'string') {
+        repoNames.add(metadata.repository);
+      }
+    }
+
+    const added: string[] = [];
+
+    for (const fullName of repoNames) {
+      // 既に登録済みかチェック
+      const existing = await this.prisma.repository.findUnique({
+        where: {
+          integrationId_fullName: {
+            integrationId: integration.id,
+            fullName,
+          },
+        },
+      });
+
+      if (existing) {
+        continue;
+      }
+
+      const [owner, name] = fullName.split('/');
+      if (!owner || !name) {
+        continue;
+      }
+
+      // GitHub APIでリポジトリ情報を取得（存在しない場合はスキップ）
+      try {
+        const repoInfo = await this.githubApiService.getRepository(
+          integration.accessToken,
+          fullName,
+        );
+
+        await this.prisma.repository.create({
+          data: {
+            integrationId: integration.id,
+            fullName,
+            owner: repoInfo?.owner || owner,
+            name: repoInfo?.name || name,
+            isPrivate: repoInfo?.isPrivate || false,
+          },
+        });
+
+        added.push(fullName);
+      } catch (error) {
+        this.logger.warn(`リポジトリ情報の取得に失敗しました: ${fullName}`, error);
+        // API取得に失敗してもFact情報から登録
+        await this.prisma.repository.create({
+          data: {
+            integrationId: integration.id,
+            fullName,
+            owner,
+            name,
+            isPrivate: false,
+          },
+        });
+        added.push(fullName);
+      }
+    }
+
+    return { added };
+  }
+}

--- a/apps/api/src/webhooks/webhooks.service.spec.ts
+++ b/apps/api/src/webhooks/webhooks.service.spec.ts
@@ -23,6 +23,9 @@ describe('WebhooksService', () => {
       findMany: jest.fn(),
       findFirst: jest.fn(),
     },
+    repository: {
+      update: jest.fn(),
+    },
   };
 
   const mockIntegrationsService = {};
@@ -123,6 +126,7 @@ describe('WebhooksService', () => {
       provider: 'github',
       accountId: 'test',
       user: { id: 'user-123' },
+      repositories: [],
     };
 
     const mockFact = {
@@ -405,6 +409,7 @@ describe('WebhooksService', () => {
         provider: 'github',
         accountId: 'test',
         user: { id: userId },
+        repositories: [],
       };
       mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
 
@@ -457,6 +462,7 @@ describe('WebhooksService', () => {
         provider: 'github',
         accountId: 'test',
         user: { id: userId },
+        repositories: [],
       };
       mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
 
@@ -491,6 +497,7 @@ describe('WebhooksService', () => {
         provider: 'github',
         accountId: 'sode0417',
         user: { id: 'user-123' },
+        repositories: [],
       };
       mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
       mockPrismaService.fact.upsert.mockResolvedValue({
@@ -524,7 +531,7 @@ describe('WebhooksService', () => {
           provider: 'github',
           accountId: 'sode0417',
         },
-        include: { user: true },
+        include: { user: true, repositories: true },
       });
     });
 
@@ -556,7 +563,7 @@ describe('WebhooksService', () => {
           provider: 'github',
           accountId: 'otheruser',
         },
-        include: { user: true },
+        include: { user: true, repositories: true },
       });
     });
 
@@ -567,6 +574,7 @@ describe('WebhooksService', () => {
         provider: 'github',
         accountId: 'myorg',
         user: { id: 'user-123' },
+        repositories: [],
       };
       mockPrismaService.integration.findFirst.mockResolvedValue(mockIntegration);
       mockPrismaService.fact.upsert.mockResolvedValue({
@@ -600,8 +608,142 @@ describe('WebhooksService', () => {
           provider: 'github',
           accountId: 'myorg',
         },
-        include: { user: true },
+        include: { user: true, repositories: true },
       });
+    });
+  });
+
+  describe('repository filtering', () => {
+    const issuePayload = {
+      action: 'opened',
+      issue: {
+        number: 1,
+        title: 'Test Issue',
+        html_url: 'https://github.com/test/repo/issues/1',
+        user: { login: 'testuser' },
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+      repository: {
+        full_name: 'test/repo',
+        html_url: 'https://github.com/test/repo',
+      },
+      sender: { login: 'testuser' },
+    };
+
+    it('Repository未登録時（0件）は全イベントを許可すること（後方互換）', async () => {
+      const integrationNoRepos = {
+        id: 'int-1',
+        userId: 'user-123',
+        provider: 'github',
+        accountId: 'test',
+        user: { id: 'user-123' },
+        repositories: [],
+      };
+      mockPrismaService.integration.findFirst.mockResolvedValue(integrationNoRepos);
+      mockPrismaService.fact.upsert.mockResolvedValue({
+        id: 'fact-1',
+        userId: 'user-123',
+        slackMessageId: null,
+      });
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toEqual({ factId: 'fact-1' });
+      expect(mockPrismaService.repository.update).not.toHaveBeenCalled();
+    });
+
+    it('登録済みリポジトリからのイベントを許可し、lastEventAtを更新すること', async () => {
+      const integrationWithRepos = {
+        id: 'int-1',
+        userId: 'user-123',
+        provider: 'github',
+        accountId: 'test',
+        user: { id: 'user-123' },
+        repositories: [
+          {
+            id: 'repo-1',
+            integrationId: 'int-1',
+            fullName: 'test/repo',
+            owner: 'test',
+            name: 'repo',
+            isPrivate: false,
+            status: 'active',
+            lastEventAt: null,
+          },
+        ],
+      };
+      mockPrismaService.integration.findFirst.mockResolvedValue(integrationWithRepos);
+      mockPrismaService.fact.upsert.mockResolvedValue({
+        id: 'fact-1',
+        userId: 'user-123',
+        slackMessageId: null,
+      });
+      mockPrismaService.repository.update.mockResolvedValue({});
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toEqual({ factId: 'fact-1' });
+      expect(mockPrismaService.repository.update).toHaveBeenCalledWith({
+        where: { id: 'repo-1' },
+        data: { lastEventAt: expect.any(Date) },
+      });
+    });
+
+    it('未登録リポジトリからのイベントを拒否すること', async () => {
+      const integrationWithOtherRepos = {
+        id: 'int-1',
+        userId: 'user-123',
+        provider: 'github',
+        accountId: 'test',
+        user: { id: 'user-123' },
+        repositories: [
+          {
+            id: 'repo-1',
+            integrationId: 'int-1',
+            fullName: 'test/other-repo',
+            owner: 'test',
+            name: 'other-repo',
+            isPrivate: false,
+            status: 'active',
+            lastEventAt: null,
+          },
+        ],
+      };
+      mockPrismaService.integration.findFirst.mockResolvedValue(integrationWithOtherRepos);
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toBeNull();
+      expect(mockPrismaService.fact.upsert).not.toHaveBeenCalled();
+    });
+
+    it('inactiveリポジトリからのイベントを拒否すること', async () => {
+      const integrationWithInactiveRepo = {
+        id: 'int-1',
+        userId: 'user-123',
+        provider: 'github',
+        accountId: 'test',
+        user: { id: 'user-123' },
+        repositories: [
+          {
+            id: 'repo-1',
+            integrationId: 'int-1',
+            fullName: 'test/repo',
+            owner: 'test',
+            name: 'repo',
+            isPrivate: false,
+            status: 'inactive',
+            lastEventAt: null,
+          },
+        ],
+      };
+      mockPrismaService.integration.findFirst.mockResolvedValue(integrationWithInactiveRepo);
+
+      const result = await service.processGitHubEvent('issues', issuePayload);
+
+      expect(result).toBeNull();
+      expect(mockPrismaService.fact.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -122,6 +122,7 @@ export class WebhooksService {
   /**
    * GitHubリポジトリに紐付くユーザーIDを取得する
    * リポジトリ名からowner (username/org) を抽出し、Integration.accountIdとマッチングする
+   * Repositoryが登録されている場合、登録済みリポジトリのみ許可する
    */
   private async findUserIdForGitHubEvent(repository: string): Promise<string | null> {
     // リポジトリ名から所有者を抽出 (例: "sode0417/factrail" -> "sode0417")
@@ -138,7 +139,10 @@ export class WebhooksService {
         provider: 'github',
         accountId: owner,
       },
-      include: { user: true },
+      include: {
+        user: true,
+        repositories: true,
+      },
     });
 
     if (!integration) {
@@ -147,6 +151,24 @@ export class WebhooksService {
           `ヒント: /auth/github にアクセスして、GitHubアカウント "${owner}" で認証を行ってください。`,
       );
       return null;
+    }
+
+    // リポジトリフィルタリング: Repositoryが1件以上登録されている場合のみフィルタ
+    if (integration.repositories.length > 0) {
+      const registered = integration.repositories.find(
+        (r) => r.fullName === repository && r.status === 'active',
+      );
+
+      if (!registered) {
+        this.logger.warn(`未登録のリポジトリからのイベントです。Factを作成しません: ${repository}`);
+        return null;
+      }
+
+      // lastEventAt を更新
+      await this.prisma.repository.update({
+        where: { id: registered.id },
+        data: { lastEventAt: new Date() },
+      });
     }
 
     return integration.userId;

--- a/apps/web/src/app/setup/github/page.tsx
+++ b/apps/web/src/app/setup/github/page.tsx
@@ -21,9 +21,18 @@ import {
   Tooltip,
   useToast,
   Spinner,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  useDisclosure,
+  InputGroup,
+  InputLeftElement,
 } from '@chakra-ui/react';
 import { MainLayout } from '@/components/layout';
-import { FiGithub, FiCopy, FiCheck, FiExternalLink, FiSave } from 'react-icons/fi';
+import { FiGithub, FiCopy, FiCheck, FiExternalLink, FiSave, FiTrash2, FiPlus, FiSearch, FiZap } from 'react-icons/fi';
 import { useState, useEffect, useCallback } from 'react';
 import apiClient from '@/lib/axios';
 
@@ -38,6 +47,25 @@ interface SettingResponse {
   updatedAt: string;
 }
 
+interface Repository {
+  id: string;
+  fullName: string;
+  owner: string;
+  name: string;
+  isPrivate: boolean;
+  status: string;
+  lastEventAt: string | null;
+  createdAt: string;
+}
+
+interface GitHubRepoInfo {
+  fullName: string;
+  name: string;
+  owner: string;
+  isPrivate: boolean;
+  htmlUrl: string;
+}
+
 export default function GitHubSetupPage() {
   const [webhookSecret, setWebhookSecret] = useState('');
   const [isConfigured, setIsConfigured] = useState(false);
@@ -45,6 +73,17 @@ export default function GitHubSetupPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [isNewSecret, setIsNewSecret] = useState(false);
   const toast = useToast();
+
+  // Repository state
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [isLoadingRepos, setIsLoadingRepos] = useState(true);
+  const [availableRepos, setAvailableRepos] = useState<GitHubRepoInfo[]>([]);
+  const [isLoadingAvailable, setIsLoadingAvailable] = useState(false);
+  const [searchFilter, setSearchFilter] = useState('');
+  const [addingRepo, setAddingRepo] = useState<string | null>(null);
+  const [removingRepo, setRemovingRepo] = useState<string | null>(null);
+  const [isDetecting, setIsDetecting] = useState(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const webhookUrl = typeof window !== 'undefined'
     ? `${API_URL}/webhooks/github`
@@ -68,9 +107,23 @@ export default function GitHubSetupPage() {
     }
   }, []);
 
+  // 登録済みリポジトリを取得
+  const fetchRepositories = useCallback(async () => {
+    try {
+      const response = await apiClient.get<Repository[]>('/repositories');
+      setRepositories(response.data);
+    } catch (_error) {
+      // GitHub連携がない場合は空配列
+      setRepositories([]);
+    } finally {
+      setIsLoadingRepos(false);
+    }
+  }, []);
+
   useEffect(() => {
     fetchSettings();
-  }, [fetchSettings]);
+    fetchRepositories();
+  }, [fetchSettings, fetchRepositories]);
 
   const generateSecret = () => {
     const array = new Uint8Array(32);
@@ -116,6 +169,127 @@ export default function GitHubSetupPage() {
     } finally {
       setIsSaving(false);
     }
+  };
+
+  // リポジトリ追加モーダルを開く
+  const openAddModal = async () => {
+    onOpen();
+    setIsLoadingAvailable(true);
+    setSearchFilter('');
+    try {
+      const response = await apiClient.get<GitHubRepoInfo[]>('/repositories/github/available');
+      setAvailableRepos(response.data);
+    } catch (error) {
+      console.error('Failed to fetch available repos:', error);
+      toast({
+        title: 'リポジトリ一覧の取得に失敗しました',
+        description: 'GitHub連携を確認してください',
+        status: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setIsLoadingAvailable(false);
+    }
+  };
+
+  // リポジトリを追加
+  const addRepository = async (fullName: string) => {
+    setAddingRepo(fullName);
+    try {
+      await apiClient.post('/repositories', { fullName });
+      toast({
+        title: 'リポジトリを追加しました',
+        description: fullName,
+        status: 'success',
+        duration: 3000,
+      });
+      await fetchRepositories();
+    } catch (error: unknown) {
+      const axiosError = error as { response?: { data?: { message?: string } } };
+      toast({
+        title: '追加に失敗しました',
+        description: axiosError.response?.data?.message || 'エラーが発生しました',
+        status: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setAddingRepo(null);
+    }
+  };
+
+  // リポジトリを削除
+  const removeRepository = async (id: string) => {
+    setRemovingRepo(id);
+    try {
+      await apiClient.delete(`/repositories/${id}`);
+      toast({
+        title: 'リポジトリを削除しました',
+        status: 'success',
+        duration: 3000,
+      });
+      await fetchRepositories();
+    } catch (error) {
+      console.error('Failed to remove repository:', error);
+      toast({
+        title: '削除に失敗しました',
+        status: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setRemovingRepo(null);
+    }
+  };
+
+  // 既存Factsから自動検出
+  const detectRepositories = async () => {
+    setIsDetecting(true);
+    try {
+      const response = await apiClient.post<{ added: string[] }>('/repositories/detect');
+      const { added } = response.data;
+      if (added.length > 0) {
+        toast({
+          title: `${added.length}件のリポジトリを検出しました`,
+          description: added.join(', '),
+          status: 'success',
+          duration: 5000,
+        });
+        await fetchRepositories();
+      } else {
+        toast({
+          title: '新しいリポジトリは見つかりませんでした',
+          status: 'info',
+          duration: 3000,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to detect repositories:', error);
+      toast({
+        title: '自動検出に失敗しました',
+        status: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setIsDetecting(false);
+    }
+  };
+
+  // 利用可能リポジトリをフィルタ（登録済みを除外 + 検索フィルタ）
+  const registeredNames = new Set(repositories.map(r => r.fullName));
+  const filteredAvailableRepos = availableRepos.filter(repo => {
+    if (registeredNames.has(repo.fullName)) return false;
+    if (searchFilter && !repo.fullName.toLowerCase().includes(searchFilter.toLowerCase())) return false;
+    return true;
+  });
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return '-';
+    return new Date(dateStr).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
   };
 
   return (
@@ -336,6 +510,96 @@ export default function GitHubSetupPage() {
           </CardBody>
         </Card>
 
+        {/* Repository Management Card */}
+        <Card bg="gray.800" borderColor="gray.700" borderWidth="1px">
+          <CardHeader>
+            <HStack justify="space-between">
+              <Text fontSize="lg" fontWeight="semibold">
+                リポジトリ管理
+              </Text>
+              <HStack spacing={2}>
+                <Button
+                  size="sm"
+                  leftIcon={<FiZap />}
+                  variant="outline"
+                  colorScheme="yellow"
+                  onClick={detectRepositories}
+                  isLoading={isDetecting}
+                  loadingText="検出中"
+                >
+                  自動検出
+                </Button>
+                <Button
+                  size="sm"
+                  leftIcon={<FiPlus />}
+                  colorScheme="brand"
+                  onClick={openAddModal}
+                >
+                  追加
+                </Button>
+              </HStack>
+            </HStack>
+          </CardHeader>
+          <CardBody>
+            {isLoadingRepos ? (
+              <HStack justify="center" py={4}>
+                <Spinner size="sm" />
+                <Text color="gray.400">読み込み中...</Text>
+              </HStack>
+            ) : repositories.length === 0 ? (
+              <Box bg="gray.900" p={4} borderRadius="lg">
+                <Text color="gray.400" fontSize="sm">
+                  リポジトリが登録されていません。リポジトリを追加すると、登録済みリポジトリからのイベントのみがFactとして記録されます。
+                </Text>
+                <Text color="gray.500" fontSize="xs" mt={2}>
+                  リポジトリ未登録の場合、すべてのリポジトリからのイベントが記録されます。
+                </Text>
+              </Box>
+            ) : (
+              <VStack spacing={3} align="stretch">
+                {repositories.map((repo) => (
+                  <HStack
+                    key={repo.id}
+                    bg="gray.900"
+                    p={3}
+                    borderRadius="lg"
+                    justify="space-between"
+                  >
+                    <HStack spacing={3}>
+                      <Icon as={FiGithub} color="gray.400" />
+                      <Box>
+                        <HStack spacing={2}>
+                          <Text fontSize="sm" fontWeight="medium">
+                            {repo.fullName}
+                          </Text>
+                          <Badge
+                            colorScheme={repo.isPrivate ? 'orange' : 'green'}
+                            fontSize="xs"
+                          >
+                            {repo.isPrivate ? 'Private' : 'Public'}
+                          </Badge>
+                        </HStack>
+                        <Text fontSize="xs" color="gray.500">
+                          最終イベント: {formatDate(repo.lastEventAt)}
+                        </Text>
+                      </Box>
+                    </HStack>
+                    <IconButton
+                      aria-label="Remove repository"
+                      icon={removingRepo === repo.id ? <Spinner size="xs" /> : <FiTrash2 />}
+                      size="sm"
+                      variant="ghost"
+                      colorScheme="red"
+                      onClick={() => removeRepository(repo.id)}
+                      isLoading={removingRepo === repo.id}
+                    />
+                  </HStack>
+                ))}
+              </VStack>
+            )}
+          </CardBody>
+        </Card>
+
         {/* External Link */}
         <Button
           as="a"
@@ -348,6 +612,89 @@ export default function GitHubSetupPage() {
           GitHub設定を開く
         </Button>
       </VStack>
+
+      {/* Add Repository Modal */}
+      <Modal isOpen={isOpen} onClose={onClose} size="lg">
+        <ModalOverlay />
+        <ModalContent bg="gray.800" borderColor="gray.700" borderWidth="1px">
+          <ModalHeader>リポジトリを追加</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <VStack spacing={4} align="stretch">
+              <InputGroup>
+                <InputLeftElement>
+                  <FiSearch color="gray" />
+                </InputLeftElement>
+                <Input
+                  placeholder="リポジトリ名で検索..."
+                  value={searchFilter}
+                  onChange={(e) => setSearchFilter(e.target.value)}
+                  bg="gray.900"
+                  borderColor="gray.700"
+                />
+              </InputGroup>
+
+              {isLoadingAvailable ? (
+                <HStack justify="center" py={8}>
+                  <Spinner size="sm" />
+                  <Text color="gray.400">GitHub APIから取得中...</Text>
+                </HStack>
+              ) : filteredAvailableRepos.length === 0 ? (
+                <Box py={4}>
+                  <Text color="gray.400" fontSize="sm" textAlign="center">
+                    {searchFilter ? '検索結果がありません' : '追加可能なリポジトリがありません'}
+                  </Text>
+                </Box>
+              ) : (
+                <VStack
+                  spacing={2}
+                  align="stretch"
+                  maxH="400px"
+                  overflowY="auto"
+                  pr={2}
+                >
+                  {filteredAvailableRepos.map((repo) => (
+                    <HStack
+                      key={repo.fullName}
+                      bg="gray.900"
+                      p={3}
+                      borderRadius="lg"
+                      justify="space-between"
+                      _hover={{ bg: 'gray.750' }}
+                    >
+                      <HStack spacing={3}>
+                        <Icon as={FiGithub} color="gray.400" />
+                        <Box>
+                          <HStack spacing={2}>
+                            <Text fontSize="sm" fontWeight="medium">
+                              {repo.fullName}
+                            </Text>
+                            <Badge
+                              colorScheme={repo.isPrivate ? 'orange' : 'green'}
+                              fontSize="xs"
+                            >
+                              {repo.isPrivate ? 'Private' : 'Public'}
+                            </Badge>
+                          </HStack>
+                        </Box>
+                      </HStack>
+                      <Button
+                        size="sm"
+                        colorScheme="brand"
+                        onClick={() => addRepository(repo.fullName)}
+                        isLoading={addingRepo === repo.fullName}
+                        loadingText="追加中"
+                      >
+                        追加
+                      </Button>
+                    </HStack>
+                  ))}
+                </VStack>
+              )}
+            </VStack>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </MainLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Repositoryモデルを追加し、リポジトリの登録・管理・Webhookフィルタリングを実現
- GitHub OAuthのaccessTokenプレースホルダーを実トークン保存に修正し、GitHub APIによるリポジトリ取得を可能にした
- フロントエンドにリポジトリ管理UI（追加モーダル・自動検出・削除）を実装

## 変更内容

### Backend
- **Prisma**: `Repository`モデル追加（Integration との1対多リレーション）
- **OAuth修正**: scopeを`repo`に拡張、実accessTokenをIntegrationに保存
- **RepositoriesModule**: 5つのAPIエンドポイント（一覧取得、GitHub候補取得、追加、削除、自動検出）
- **Webhookフィルタリング**: リポジトリ登録がある場合は登録済みリポジトリのみ許可（0件時は後方互換で全許可）

### Frontend
- GitHub設定ページに「リポジトリ管理」カードを追加
- リポジトリ追加モーダル（GitHub API候補表示 + 検索フィルタ）
- 既存Factsからの自動検出ボタン

### テスト
- `repositories.service.spec.ts`: 9テスト（CRUD、GitHub API、自動検出）
- `webhooks.service.spec.ts`: リポジトリフィルタリング4テスト追加（後方互換、許可、拒否、inactive拒否）
- 全33テスト パス

## Test plan
- [ ] マイグレーション適用確認
- [ ] GitHub OAuth再ログインで実accessTokenが保存されること
- [ ] `GET /repositories/github/available` でリポジトリ一覧取得
- [ ] `POST /repositories` でリポジトリ追加 → `GET /repositories` で表示
- [ ] 登録済みリポジトリからのWebhook → Fact作成される
- [ ] 未登録リポジトリからのWebhook → Fact作成されない
- [ ] Repository 0件時は旧動作（全受入）を維持
- [ ] フロントエンドUIでのリポジトリ追加・削除操作

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)