### PR TITLE
🤖 共通Integration基盤: インターフェース定義 + BaseProvider

### DIFF
--- a/apps/api/src/integrations/providers/base.provider.spec.ts
+++ b/apps/api/src/integrations/providers/base.provider.spec.ts
@@ -1,0 +1,241 @@
+import { DecryptedIntegration } from '../integrations.service';
+import { BaseProvider } from './base.provider';
+import { OAuthTokenResponse, ConnectionStatus } from './integration-provider.interface';
+
+/**
+ * テスト用の具象プロバイダー
+ */
+class TestProvider extends BaseProvider {
+  readonly providerName = 'test';
+
+  async exchangeOAuthCode(code: string): Promise<OAuthTokenResponse> {
+    return {
+      accessToken: `token-${code}`,
+      accountId: 'test-account',
+      accountName: 'Test Account',
+    };
+  }
+
+  async validateConnection(_integration: DecryptedIntegration): Promise<ConnectionStatus> {
+    return { connected: true };
+  }
+}
+
+/**
+ * refreshAccessToken をオーバーライドしたテスト用プロバイダー
+ */
+class RefreshableTestProvider extends BaseProvider {
+  readonly providerName = 'refreshable-test';
+
+  async exchangeOAuthCode(code: string): Promise<OAuthTokenResponse> {
+    return {
+      accessToken: `token-${code}`,
+      accountId: 'test-account',
+    };
+  }
+
+  async refreshAccessToken(_integration: DecryptedIntegration): Promise<OAuthTokenResponse> {
+    return {
+      accessToken: 'refreshed-token',
+      accountId: 'test-account',
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+    };
+  }
+
+  async validateConnection(_integration: DecryptedIntegration): Promise<ConnectionStatus> {
+    return { connected: true };
+  }
+}
+
+function createMockIntegration(overrides: Partial<DecryptedIntegration> = {}): DecryptedIntegration {
+  return {
+    id: 'int-1',
+    provider: 'test',
+    accountId: 'acc-1',
+    accountName: 'Test',
+    accessToken: 'valid-token',
+    refreshToken: null,
+    expiresAt: null,
+    scope: [],
+    status: 'active',
+    lastSyncAt: null,
+    userId: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('BaseProvider', () => {
+  let provider: TestProvider;
+
+  beforeEach(() => {
+    provider = new TestProvider();
+  });
+
+  describe('providerName', () => {
+    it('具象クラスで定義した名前を返す', () => {
+      expect(provider.providerName).toBe('test');
+    });
+  });
+
+  describe('exchangeOAuthCode', () => {
+    it('具象クラスの実装が呼ばれる', async () => {
+      const result = await provider.exchangeOAuthCode('auth-code-123');
+      expect(result).toEqual({
+        accessToken: 'token-auth-code-123',
+        accountId: 'test-account',
+        accountName: 'Test Account',
+      });
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('デフォルト実装はエラーをスローする', async () => {
+      const integration = createMockIntegration();
+      await expect(provider.refreshAccessToken(integration)).rejects.toThrow(
+        'test はトークンリフレッシュに対応していません',
+      );
+    });
+
+    it('オーバーライドすればリフレッシュできる', async () => {
+      const refreshableProvider = new RefreshableTestProvider();
+      const integration = createMockIntegration();
+      const result = await refreshableProvider.refreshAccessToken(integration);
+      expect(result.accessToken).toBe('refreshed-token');
+    });
+  });
+
+  describe('validateConnection', () => {
+    it('具象クラスの実装が呼ばれる', async () => {
+      const integration = createMockIntegration();
+      const result = await provider.validateConnection(integration);
+      expect(result).toEqual({ connected: true });
+    });
+  });
+
+  describe('isTokenExpired', () => {
+    it('expiresAt が null なら期限切れではない', () => {
+      const integration = createMockIntegration({ expiresAt: null });
+      expect(provider.isTokenExpired(integration)).toBe(false);
+    });
+
+    it('未来の expiresAt（5分超）なら期限切れではない', () => {
+      const future = new Date(Date.now() + 10 * 60 * 1000); // 10分後
+      const integration = createMockIntegration({ expiresAt: future });
+      expect(provider.isTokenExpired(integration)).toBe(false);
+    });
+
+    it('5分以内の expiresAt は期限切れとみなす', () => {
+      const soon = new Date(Date.now() + 3 * 60 * 1000); // 3分後
+      const integration = createMockIntegration({ expiresAt: soon });
+      expect(provider.isTokenExpired(integration)).toBe(true);
+    });
+
+    it('過去の expiresAt は期限切れ', () => {
+      const past = new Date(Date.now() - 60 * 1000); // 1分前
+      const integration = createMockIntegration({ expiresAt: past });
+      expect(provider.isTokenExpired(integration)).toBe(true);
+    });
+  });
+
+  describe('ensureValidToken', () => {
+    it('トークンが有効ならそのまま返す', async () => {
+      const integration = createMockIntegration({ expiresAt: null });
+      const result = await provider.ensureValidToken(integration);
+      expect(result).toEqual({
+        accessToken: 'valid-token',
+        refreshed: false,
+      });
+    });
+
+    it('トークンが期限切れでリフレッシュ非対応ならエラー', async () => {
+      const expired = new Date(Date.now() - 60 * 1000);
+      const integration = createMockIntegration({ expiresAt: expired });
+      await expect(provider.ensureValidToken(integration)).rejects.toThrow(
+        'test はトークンリフレッシュに対応していません',
+      );
+    });
+
+    it('トークンが期限切れでリフレッシュ対応ならリフレッシュする', async () => {
+      const refreshableProvider = new RefreshableTestProvider();
+      const expired = new Date(Date.now() - 60 * 1000);
+      const integration = createMockIntegration({ expiresAt: expired });
+
+      const result = await refreshableProvider.ensureValidToken(integration);
+      expect(result.accessToken).toBe('refreshed-token');
+      expect(result.refreshed).toBe(true);
+      expect(result.tokenResponse).toBeDefined();
+    });
+  });
+
+  describe('fetchWithRetry', () => {
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+      // delay をモックして即時解決にする
+      jest.spyOn(provider as any, 'delay').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.restoreAllMocks();
+    });
+
+    it('成功時はレスポンスを返す', async () => {
+      const mockResponse = new Response('ok', { status: 200 });
+      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+      const result = await (provider as any).fetchWithRetry('https://example.com', {});
+      expect(result.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('失敗後にリトライして成功する', async () => {
+      const mockResponse = new Response('ok', { status: 200 });
+      global.fetch = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await (provider as any).fetchWithRetry('https://example.com', {});
+      expect(result.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('全リトライ失敗時はエラーをスローする', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('persistent error'));
+
+      await expect(
+        (provider as any).fetchWithRetry('https://example.com', {}, 1),
+      ).rejects.toThrow('persistent error');
+      expect(global.fetch).toHaveBeenCalledTimes(2); // 初回 + 1リトライ
+    });
+  });
+
+  describe('registerWebhook', () => {
+    it('デフォルト実装はエラーをスローする', async () => {
+      const integration = createMockIntegration();
+      await expect(
+        provider.registerWebhook(integration, { url: 'https://example.com', events: ['push'] }),
+      ).rejects.toThrow('test は Webhook 登録に対応していません');
+    });
+  });
+
+  describe('removeWebhook', () => {
+    it('デフォルト実装はエラーをスローする', async () => {
+      const integration = createMockIntegration();
+      await expect(provider.removeWebhook(integration, 'wh-1')).rejects.toThrow(
+        'test は Webhook 解除に対応していません',
+      );
+    });
+  });
+
+  describe('onDisconnect', () => {
+    it('デフォルト実装はエラーなく完了する', async () => {
+      const integration = createMockIntegration();
+      await expect(provider.onDisconnect(integration)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/integrations/providers/base.provider.ts
+++ b/apps/api/src/integrations/providers/base.provider.ts
@@ -1,0 +1,142 @@
+import { Logger } from '@nestjs/common';
+import { DecryptedIntegration } from '../integrations.service';
+import {
+  IntegrationProvider,
+  OAuthTokenResponse,
+  WebhookConfig,
+  ConnectionStatus,
+} from './integration-provider.interface';
+
+/**
+ * プロバイダーの共通ロジックを提供する抽象基底クラス
+ *
+ * 各プロバイダーはこのクラスを継承し、抽象メソッドを実装する。
+ * トークンリフレッシュ判定、HTTP リクエストのリトライ、ロギングなど
+ * 共通処理をここに集約する。
+ */
+export abstract class BaseProvider implements IntegrationProvider {
+  protected readonly logger: Logger;
+
+  abstract readonly providerName: string;
+
+  constructor() {
+    this.logger = new Logger(this.constructor.name);
+  }
+
+  abstract exchangeOAuthCode(code: string, redirectUri?: string): Promise<OAuthTokenResponse>;
+
+  /**
+   * デフォルト実装: トークンリフレッシュ非対応
+   * リフレッシュ対応のプロバイダーはオーバーライドする
+   */
+  async refreshAccessToken(_integration: DecryptedIntegration): Promise<OAuthTokenResponse> {
+    throw new Error(`${this.providerName} はトークンリフレッシュに対応していません`);
+  }
+
+  abstract validateConnection(integration: DecryptedIntegration): Promise<ConnectionStatus>;
+
+  /**
+   * トークンが期限切れ、または期限切れ間近（5分以内）かどうかを判定する
+   */
+  isTokenExpired(integration: DecryptedIntegration): boolean {
+    if (!integration.expiresAt) {
+      return false;
+    }
+
+    const expiresAt = new Date(integration.expiresAt);
+    const now = new Date();
+    const bufferMs = 5 * 60 * 1000;
+
+    return expiresAt.getTime() <= now.getTime() + bufferMs;
+  }
+
+  /**
+   * 必要に応じてトークンをリフレッシュし、有効なトークンを返す
+   *
+   * トークンが有効ならそのまま返し、期限切れなら refreshAccessToken を呼ぶ。
+   * リフレッシュ非対応の場合はエラーをスローする。
+   */
+  async ensureValidToken(
+    integration: DecryptedIntegration,
+  ): Promise<{ accessToken: string; refreshed: boolean; tokenResponse?: OAuthTokenResponse }> {
+    if (!this.isTokenExpired(integration)) {
+      return { accessToken: integration.accessToken, refreshed: false };
+    }
+
+    this.logger.log(`${this.providerName}: トークンの期限切れを検出、リフレッシュを試行`);
+    const tokenResponse = await this.refreshAccessToken(integration);
+    return {
+      accessToken: tokenResponse.accessToken,
+      refreshed: true,
+      tokenResponse,
+    };
+  }
+
+  /**
+   * HTTP リクエストをリトライ付きで実行する
+   *
+   * @param url リクエスト先 URL
+   * @param options fetch のオプション
+   * @param maxRetries 最大リトライ回数（デフォルト: 2）
+   */
+  protected async fetchWithRetry(
+    url: string,
+    options: RequestInit,
+    maxRetries = 2,
+  ): Promise<Response> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const response = await fetch(url, options);
+        return response;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt < maxRetries) {
+          const delayMs = Math.pow(2, attempt) * 1000;
+          this.logger.warn(
+            `${this.providerName}: リクエスト失敗 (${attempt + 1}/${maxRetries + 1}), ${delayMs}ms 後にリトライ`,
+          );
+          await this.delay(delayMs);
+        }
+      }
+    }
+
+    throw lastError;
+  }
+
+  /**
+   * 指定ミリ秒待機する（テスト時にモック可能）
+   */
+  protected delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Webhook 登録のデフォルト実装（非対応）
+   * 対応プロバイダーはオーバーライドする
+   */
+  async registerWebhook(
+    _integration: DecryptedIntegration,
+    _config: WebhookConfig,
+  ): Promise<string> {
+    throw new Error(`${this.providerName} は Webhook 登録に対応していません`);
+  }
+
+  /**
+   * Webhook 解除のデフォルト実装（非対応）
+   */
+  async removeWebhook(
+    _integration: DecryptedIntegration,
+    _webhookId: string,
+  ): Promise<void> {
+    throw new Error(`${this.providerName} は Webhook 解除に対応していません`);
+  }
+
+  /**
+   * 連携解除時のクリーンアップ（デフォルト: 何もしない）
+   */
+  async onDisconnect(_integration: DecryptedIntegration): Promise<void> {
+    this.logger.log(`${this.providerName}: 連携解除のクリーンアップ（デフォルト: なし）`);
+  }
+}

--- a/apps/api/src/integrations/providers/index.ts
+++ b/apps/api/src/integrations/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './integration-provider.interface';
+export * from './base.provider';

--- a/apps/api/src/integrations/providers/integration-provider.interface.ts
+++ b/apps/api/src/integrations/providers/integration-provider.interface.ts
@@ -1,0 +1,73 @@
+import { DecryptedIntegration } from '../integrations.service';
+
+/**
+ * OAuth トークンレスポンスの型
+ */
+export interface OAuthTokenResponse {
+  accessToken: string;
+  refreshToken?: string | null;
+  expiresAt?: Date | null;
+  scope?: string[];
+  accountId: string;
+  accountName?: string;
+}
+
+/**
+ * Webhook 設定の型
+ */
+export interface WebhookConfig {
+  url: string;
+  secret?: string;
+  events: string[];
+}
+
+/**
+ * 接続ステータスの型
+ */
+export interface ConnectionStatus {
+  connected: boolean;
+  message?: string;
+}
+
+/**
+ * 各プロバイダーが実装する統一インターフェース
+ *
+ * 新しい外部サービスを追加する際は、このインターフェースを実装して
+ * プロバイダー固有のロジックをカプセル化する。
+ */
+export interface IntegrationProvider {
+  /**
+   * プロバイダー識別子（例: 'github', 'slack', 'google'）
+   */
+  readonly providerName: string;
+
+  /**
+   * OAuth コールバックでトークンを交換する
+   */
+  exchangeOAuthCode(code: string, redirectUri?: string): Promise<OAuthTokenResponse>;
+
+  /**
+   * トークンをリフレッシュする（対応している場合）
+   */
+  refreshAccessToken(integration: DecryptedIntegration): Promise<OAuthTokenResponse>;
+
+  /**
+   * 接続状態を検証する（トークンが有効かどうか）
+   */
+  validateConnection(integration: DecryptedIntegration): Promise<ConnectionStatus>;
+
+  /**
+   * Webhook を登録する（対応している場合）
+   */
+  registerWebhook?(integration: DecryptedIntegration, config: WebhookConfig): Promise<string>;
+
+  /**
+   * Webhook を解除する（対応している場合）
+   */
+  removeWebhook?(integration: DecryptedIntegration, webhookId: string): Promise<void>;
+
+  /**
+   * 連携を解除する際のクリーンアップ処理
+   */
+  onDisconnect?(integration: DecryptedIntegration): Promise<void>;
+}


### PR DESCRIPTION
## Claude Code による自動実行 (Planner → Coder → Reviewer → Test → QA)

**プロンプト:** v1.0マイルストーン(3/31期限)に向けて、IntegrationProvider インターフェースと BaseProvider 抽象クラスを実装する。

<details>
<summary>📋 実装計画 (Planner Agent)</summary>

コードベースの構造を十分に把握しました。以下が実装計画です。

---

## 実装計画: IntegrationProvider インターフェース + BaseProvider 抽象クラス

### 現状分析

現在の integrations モジュールは:
- `IntegrationsService` — CRUD 操作（トークン暗号化/復号化含む）
- `SlackOAuthService` — Slack 固有の OAuth フロー
- `WebhooksService` — GitHub 固有の Webhook 処理
- `SlackDispatcherService` — Slack 固有の投稿処理
- `GitHubApiService` — GitHub API 操作

**問題:** 各プロバイダー固有のロジックがバラバラに散在しており、新プロバイダー追加時に統一的なパターンがない。

### 変更対象ファイル

| ファイル | 変更種別 | 概要 |
|---------|---------|------|
| `apps/api/src/integrations/providers/integration-provider.interface.ts` | **新規** | `IntegrationProvider` インターフェース定義 |
| `apps/api/src/integrations/providers/base.provider.ts` | **新規** | `BaseProvider` 抽象クラス（共通ロジック実装） |
| `apps/api/src/integrations/providers/index.ts` | **新規** | barrel export |
| `apps/api/src/integrations/providers/base.provider.spec.ts` | **新規** | BaseProvider のユニットテスト |

**既存ファイルの変更なし。** インターフェースと基盤クラスの定義のみなので、既存コードへの統合は次のステップ（各プロバイダーの Provider 実装）で行う。

### 実装手順

#### 1. `IntegrationProvider` インターフェー

</details>

<details>
<summary>🔍 コードレビュー (Reviewer Agent)</summary>

APPROVE

全体的に設計が明確で、計画通りのファイル構成・実装になっています。以下、所見をまとめます。

---

### 良い点

- **インターフェース設計が適切**: `IntegrationProvider` の必須/オプショナルの分け方が合理的。Webhook 系はプロバイダーによって非対応があるためオプショナルで正しい。
- **BaseProvider のデフォルト実装パターン**: 非対応メソッドは `throw` するデフォルト実装、`onDisconnect` は no-op というのは Template Method パターンとして妥当。
- **テストが網羅的**: `isTokenExpired` のエッジケース（null、5分超、5分以内、過去）や `fetchWithRetry` のリトライシナリオまでカバーしている。
- **`delay` メソッドの分離**: テストで `jest.spyOn` できるようにリトライの sleep を分離しているのは良いテスタビリティ設計。

### 軽微な指摘（APPROVE のまま）

1. **`isTokenExpired` の重複** (`base.provider.ts:41` と `integrations.service.ts:246`): 同じロジックが `IntegrationsService` にも存在する。次ステップで既存プロバイダーを `BaseProvider` に移行する際に、`IntegrationsService` 側を削除するか委譲するかの整理が必要。

2. **`fetchWithRetry` は HTTP エラーステータスではリトライしない** (`base.provider.ts:91`): 現在はネットワークエラー（fetch 自体の例外）のみリトライ対

</details>


---
🤖 Generated by Claude Code via ai-assistant (Mac mini)