### PR TITLE
Fact 編集・削除機能

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -5024,9 +5024,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -86,7 +86,8 @@
   "overrides": {
     "axios": ">=1.13.5",
     "qs": ">=6.15.0",
-    "multer": ">=2.1.0"
+    "multer": ">=2.1.0",
+    "effect": ">=3.20.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/api/src/backup/backup.controller.spec.ts
+++ b/apps/api/src/backup/backup.controller.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BackupController } from './backup.controller';
+import { BackupService } from './backup.service';
+
+describe('BackupController', () => {
+  let controller: BackupController;
+
+  const mockBackupService = {
+    createUserBackup: jest.fn(),
+  };
+
+  const mockRequest = { user: { id: 'user-123' } };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BackupController],
+      providers: [
+        { provide: BackupService, useValue: mockBackupService },
+      ],
+    }).compile();
+
+    controller = module.get<BackupController>(BackupController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('trigger', () => {
+    it('バックアップデータを JSON として返すこと', async () => {
+      const mockBackup = {
+        metadata: { version: '1.0', createdAt: '2024-01-01', userId: 'user-123' },
+        facts: [],
+        integrations: [],
+        repositories: [],
+      };
+      mockBackupService.createUserBackup.mockResolvedValue(mockBackup);
+
+      const mockRes = {
+        setHeader: jest.fn(),
+        send: jest.fn(),
+      };
+
+      await controller.trigger(mockRequest, mockRes as any);
+
+      expect(mockBackupService.createUserBackup).toHaveBeenCalledWith('user-123');
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        expect.stringContaining('attachment; filename="factrail-backup-'),
+      );
+      expect(mockRes.send).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/backup/backup.service.spec.ts
+++ b/apps/api/src/backup/backup.service.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BackupService } from './backup.service';
+import { PrismaService } from '../prisma.service';
+
+describe('BackupService', () => {
+  let service: BackupService;
+
+  const mockPrismaService = {
+    fact: { findMany: jest.fn(), count: jest.fn() },
+    integration: { findMany: jest.fn(), count: jest.fn() },
+    repository: { findMany: jest.fn(), count: jest.fn() },
+    user: { count: jest.fn() },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BackupService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<BackupService>(BackupService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createUserBackup', () => {
+    it('ユーザーデータをエクスポートできること', async () => {
+      const mockFacts = [{ id: 'fact-1', title: 'Test' }];
+      const mockIntegrations = [{ id: 'int-1', provider: 'github' }];
+      const mockRepositories = [{ id: 'repo-1', name: 'test-repo' }];
+
+      mockPrismaService.fact.findMany.mockResolvedValue(mockFacts);
+      mockPrismaService.integration.findMany.mockResolvedValue(mockIntegrations);
+      mockPrismaService.repository.findMany.mockResolvedValue(mockRepositories);
+
+      const result = await service.createUserBackup('user-123');
+
+      expect(result.metadata.version).toBe('1.0');
+      expect(result.metadata.userId).toBe('user-123');
+      expect(result.metadata.createdAt).toBeDefined();
+      expect(result.facts).toEqual(mockFacts);
+      expect(result.integrations).toEqual(mockIntegrations);
+      expect(result.repositories).toEqual(mockRepositories);
+    });
+  });
+
+  describe('scheduledBackup', () => {
+    it('スケジュールバックアップがログ出力すること', async () => {
+      mockPrismaService.fact.count.mockResolvedValue(100);
+      mockPrismaService.integration.count.mockResolvedValue(5);
+      mockPrismaService.repository.count.mockResolvedValue(10);
+      mockPrismaService.user.count.mockResolvedValue(1);
+
+      await service.scheduledBackup();
+
+      expect(mockPrismaService.fact.count).toHaveBeenCalled();
+      expect(mockPrismaService.user.count).toHaveBeenCalled();
+    });
+
+    it('エラー時にログ出力すること', async () => {
+      mockPrismaService.fact.count.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.scheduledBackup()).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/facts/dto/index.ts
+++ b/apps/api/src/facts/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './query-facts.dto';
 export * from './create-fact.dto';
+export * from './update-fact.dto';
 export * from './stats-response.dto';

--- a/apps/api/src/facts/dto/update-fact.dto.ts
+++ b/apps/api/src/facts/dto/update-fact.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsOptional, IsNotEmpty, IsUUID, ValidateIf } from 'class-validator';
+
+export class UpdateFactDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  summary?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsUUID()
+  projectId?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsUUID()
+  categoryId?: string | null;
+}

--- a/apps/api/src/facts/facts.controller.spec.ts
+++ b/apps/api/src/facts/facts.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FactsController } from './facts.controller';
 import { FactsService } from './facts.service';
-import { CreateFactDto, QueryFactsDto } from './dto';
+import { CreateFactDto, UpdateFactDto, QueryFactsDto } from './dto';
 
 describe('FactsController', () => {
   let controller: FactsController;
@@ -12,6 +12,8 @@ describe('FactsController', () => {
     findOne: jest.fn(),
     findChildren: jest.fn(),
     create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
     getStats: jest.fn(),
   };
 
@@ -226,6 +228,29 @@ describe('FactsController', () => {
 
       expect(result).toEqual(mockCreatedFact);
       expect(service.create).toHaveBeenCalledWith('user-123', fullDto);
+    });
+  });
+
+  describe('update', () => {
+    it('記録を更新できること', async () => {
+      const updateDto: UpdateFactDto = { title: 'Updated Title' };
+      const mockUpdated = { data: { id: 'fact-1', title: 'Updated Title' } };
+      mockFactsService.update.mockResolvedValue(mockUpdated);
+
+      const result = await controller.update(mockRequest, 'fact-1', updateDto);
+
+      expect(result).toEqual(mockUpdated);
+      expect(service.update).toHaveBeenCalledWith('user-123', 'fact-1', updateDto);
+    });
+  });
+
+  describe('remove', () => {
+    it('記録を削除できること', async () => {
+      mockFactsService.remove.mockResolvedValue(undefined);
+
+      await controller.remove(mockRequest, 'fact-1');
+
+      expect(service.remove).toHaveBeenCalledWith('user-123', 'fact-1');
     });
   });
 });

--- a/apps/api/src/facts/facts.controller.ts
+++ b/apps/api/src/facts/facts.controller.ts
@@ -2,6 +2,8 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
+  Delete,
   Body,
   Param,
   Query,
@@ -12,7 +14,7 @@ import {
   Request,
 } from '@nestjs/common';
 import { FactsService } from './facts.service';
-import { CreateFactDto, QueryFactsDto } from './dto';
+import { CreateFactDto, UpdateFactDto, QueryFactsDto } from './dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 /**
@@ -72,5 +74,20 @@ export class FactsController {
   @HttpCode(HttpStatus.CREATED)
   create(@Request() req, @Body() createFactDto: CreateFactDto) {
     return this.factsService.create(req.user.id, createFactDto);
+  }
+
+  @Patch(':id')
+  update(
+    @Request() req,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateFactDto: UpdateFactDto,
+  ) {
+    return this.factsService.update(req.user.id, id, updateFactDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
+    return this.factsService.remove(req.user.id, id);
   }
 }

--- a/apps/api/src/facts/facts.service.spec.ts
+++ b/apps/api/src/facts/facts.service.spec.ts
@@ -187,6 +187,32 @@ describe('FactsService', () => {
       expect(result.meta.nextCursor).toBe('fact-49');
     });
 
+    it('projectId でフィルタリングできること', async () => {
+      mockPrismaService.fact.findMany.mockResolvedValue([]);
+
+      const query: QueryFactsDto = { projectId: 'proj-1' };
+      await service.findAll(userId, query);
+
+      expect(prisma.fact.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId, projectId: 'proj-1' }),
+        }),
+      );
+    });
+
+    it('categoryId でフィルタリングできること', async () => {
+      mockPrismaService.fact.findMany.mockResolvedValue([]);
+
+      const query: QueryFactsDto = { categoryId: 'cat-1' };
+      await service.findAll(userId, query);
+
+      expect(prisma.fact.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId, categoryId: 'cat-1' }),
+        }),
+      );
+    });
+
     it('次ページがない場合にhasMoreがfalseであること', async () => {
       mockPrismaService.fact.findMany.mockResolvedValue(mockFacts);
 
@@ -582,6 +608,15 @@ describe('FactsService', () => {
       mockPrismaService.fact.findFirst.mockResolvedValue(null);
 
       await expect(service.update(userId, factId, { title: 'New' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('更新フィールドがない場合はそのまま返すこと', async () => {
+      mockPrismaService.fact.findFirst.mockResolvedValue(manualFact);
+
+      const result = await service.update(userId, factId, {});
+
+      expect(result.data).toEqual(manualFact);
+      expect(mockPrismaService.fact.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/facts/facts.service.spec.ts
+++ b/apps/api/src/facts/facts.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { FactsService } from './facts.service';
 import { PrismaService } from '../prisma.service';
-import { CreateFactDto, QueryFactsDto } from './dto';
+import { CreateFactDto, UpdateFactDto, QueryFactsDto } from './dto';
 
 describe('FactsService', () => {
   let service: FactsService;
@@ -15,6 +15,8 @@ describe('FactsService', () => {
       create: jest.fn(),
       count: jest.fn(),
       update: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
     },
   };
 
@@ -502,6 +504,131 @@ describe('FactsService', () => {
       const result = await service.getStats(userId);
 
       expect(result.todayCount).toBe(0);
+    });
+  });
+
+  describe('update', () => {
+    const userId = 'user-123';
+    const factId = 'fact-1';
+    const manualFact = {
+      id: factId,
+      source: 'manual',
+      type: 'memo',
+      userId,
+      title: 'Original',
+      summary: null,
+      projectId: null,
+      categoryId: null,
+    };
+
+    it('manual Fact のタイトルを更新できること', async () => {
+      mockPrismaService.fact.findFirst.mockResolvedValue(manualFact);
+      const updatedFact = { ...manualFact, title: 'Updated Title' };
+      mockPrismaService.fact.update.mockResolvedValue(updatedFact);
+
+      const dto: UpdateFactDto = { title: 'Updated Title' };
+      const result = await service.update(userId, factId, dto);
+
+      expect(result.data.title).toBe('Updated Title');
+      expect(mockPrismaService.fact.update).toHaveBeenCalledWith({
+        where: { id: factId },
+        data: { title: 'Updated Title' },
+      });
+    });
+
+    it('comment Fact を更新できること', async () => {
+      const commentFact = { ...manualFact, source: 'comment', type: 'comment' };
+      mockPrismaService.fact.findFirst.mockResolvedValue(commentFact);
+      mockPrismaService.fact.update.mockResolvedValue({ ...commentFact, title: 'New' });
+
+      const result = await service.update(userId, factId, { title: 'New' });
+      expect(result.data.title).toBe('New');
+    });
+
+    it('projectId を null に設定解除できること', async () => {
+      const factWithProject = { ...manualFact, projectId: 'proj-1' };
+      mockPrismaService.fact.findFirst.mockResolvedValue(factWithProject);
+      mockPrismaService.fact.update.mockResolvedValue({ ...factWithProject, projectId: null });
+
+      await service.update(userId, factId, { projectId: null });
+
+      expect(mockPrismaService.fact.update).toHaveBeenCalledWith({
+        where: { id: factId },
+        data: { projectId: null },
+      });
+    });
+
+    it('categoryId を null に設定解除できること', async () => {
+      const factWithCategory = { ...manualFact, categoryId: 'cat-1' };
+      mockPrismaService.fact.findFirst.mockResolvedValue(factWithCategory);
+      mockPrismaService.fact.update.mockResolvedValue({ ...factWithCategory, categoryId: null });
+
+      await service.update(userId, factId, { categoryId: null });
+
+      expect(mockPrismaService.fact.update).toHaveBeenCalledWith({
+        where: { id: factId },
+        data: { categoryId: null },
+      });
+    });
+
+    it('外部ソースの Fact は更新できないこと', async () => {
+      const githubFact = { ...manualFact, source: 'github' };
+      mockPrismaService.fact.findFirst.mockResolvedValue(githubFact);
+
+      await expect(service.update(userId, factId, { title: 'New' })).rejects.toThrow(ForbiddenException);
+    });
+
+    it('存在しない Fact は NotFoundException をスローすること', async () => {
+      mockPrismaService.fact.findFirst.mockResolvedValue(null);
+
+      await expect(service.update(userId, factId, { title: 'New' })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    const userId = 'user-123';
+    const factId = 'fact-1';
+    const manualFact = {
+      id: factId,
+      source: 'manual',
+      type: 'memo',
+      userId,
+    };
+
+    it('manual Fact を削除できること（子も削除）', async () => {
+      mockPrismaService.fact.findFirst.mockResolvedValue(manualFact);
+      mockPrismaService.fact.deleteMany.mockResolvedValue({ count: 2 });
+      mockPrismaService.fact.delete.mockResolvedValue(manualFact);
+
+      await service.remove(userId, factId);
+
+      expect(mockPrismaService.fact.deleteMany).toHaveBeenCalledWith({ where: { parentId: factId } });
+      expect(mockPrismaService.fact.delete).toHaveBeenCalledWith({ where: { id: factId } });
+    });
+
+    it('comment Fact を削除できること', async () => {
+      const commentFact = { ...manualFact, source: 'comment', type: 'comment' };
+      mockPrismaService.fact.findFirst.mockResolvedValue(commentFact);
+      mockPrismaService.fact.deleteMany.mockResolvedValue({ count: 0 });
+      mockPrismaService.fact.delete.mockResolvedValue(commentFact);
+
+      await service.remove(userId, factId);
+
+      expect(mockPrismaService.fact.deleteMany).toHaveBeenCalledWith({ where: { parentId: factId } });
+      expect(mockPrismaService.fact.delete).toHaveBeenCalledWith({ where: { id: factId } });
+    });
+
+    it('外部ソースの Fact は削除できないこと', async () => {
+      const githubFact = { ...manualFact, source: 'github' };
+      mockPrismaService.fact.findFirst.mockResolvedValue(githubFact);
+
+      await expect(service.remove(userId, factId)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('存在しない Fact は NotFoundException をスローすること', async () => {
+      mockPrismaService.fact.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove(userId, factId)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/facts/facts.service.ts
+++ b/apps/api/src/facts/facts.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
-import { CreateFactDto, QueryFactsDto, FactsStatsResponseDto } from './dto';
+import { CreateFactDto, UpdateFactDto, QueryFactsDto, FactsStatsResponseDto } from './dto';
 import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
@@ -227,5 +227,59 @@ export class FactsService {
     return {
       todayCount,
     };
+  }
+
+  /**
+   * 記録を更新する（manual / comment のみ）
+   */
+  async update(userId: string, id: string, dto: UpdateFactDto) {
+    const fact = await this.prisma.fact.findFirst({
+      where: { id, userId },
+    });
+
+    if (!fact) {
+      throw new NotFoundException(`記録が見つかりません: ID "${id}"`);
+    }
+
+    if (fact.source !== 'manual' && fact.source !== 'comment') {
+      throw new ForbiddenException('外部ソースの記録は編集できません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (dto.title !== undefined) data.title = dto.title;
+    if (dto.summary !== undefined) data.summary = dto.summary;
+    if (dto.projectId !== undefined) data.projectId = dto.projectId;
+    if (dto.categoryId !== undefined) data.categoryId = dto.categoryId;
+
+    if (Object.keys(data).length === 0) {
+      return { data: fact };
+    }
+
+    const updated = await this.prisma.fact.update({
+      where: { id },
+      data,
+    });
+
+    return { data: updated };
+  }
+
+  /**
+   * 記録を削除する（manual / comment のみ、子 Fact も削除）
+   */
+  async remove(userId: string, id: string) {
+    const fact = await this.prisma.fact.findFirst({
+      where: { id, userId },
+    });
+
+    if (!fact) {
+      throw new NotFoundException(`記録が見つかりません: ID "${id}"`);
+    }
+
+    if (fact.source !== 'manual' && fact.source !== 'comment') {
+      throw new ForbiddenException('外部ソースの記録は削除できません');
+    }
+
+    await this.prisma.fact.deleteMany({ where: { parentId: id } });
+    await this.prisma.fact.delete({ where: { id } });
   }
 }

--- a/apps/web/src/app/facts/page.tsx
+++ b/apps/web/src/app/facts/page.tsx
@@ -20,10 +20,16 @@ import {
   IconButton,
   Textarea,
   useToast,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
 } from '@chakra-ui/react';
 import { MainLayout } from '@/components/layout';
 import { DateFilter } from '@/components/facts';
-import { FiSearch, FiExternalLink, FiRefreshCw, FiMessageSquare, FiChevronDown, FiChevronRight, FiSend } from 'react-icons/fi';
+import { FiSearch, FiExternalLink, FiRefreshCw, FiMessageSquare, FiChevronDown, FiChevronRight, FiSend, FiEdit2, FiTrash2, FiCheck, FiX } from 'react-icons/fi';
 import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
 import apiClient, { f2aClient } from '@/lib/axios';
 import { formatRelativeTime } from '@/lib/formatRelativeTime';
@@ -126,6 +132,21 @@ function FactsPageContent() {
   // フィルタ用カテゴリ/プロジェクト
   const [filterCategoryId, setFilterCategoryId] = useState('');
   const [filterProjectId, setFilterProjectId] = useState('');
+
+  // インライン編集
+  const [editingFactId, setEditingFactId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<{
+    title: string;
+    summary: string;
+    projectId: string | null;
+    categoryId: string | null;
+  }>({ title: '', summary: '', projectId: null, categoryId: null });
+  const [isSaving, setIsSaving] = useState(false);
+
+  // 削除確認
+  const [deletingFact, setDeletingFact] = useState<Fact | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const cancelDeleteRef = useRef<HTMLButtonElement>(null);
 
   const {
     from,
@@ -284,6 +305,97 @@ function FactsPageContent() {
       handleSendMemo();
     }
   }, [handleSendMemo]);
+
+  // インライン編集開始
+  const startEditing = useCallback((fact: Fact) => {
+    setEditingFactId(fact.id);
+    setEditForm({
+      title: fact.title,
+      summary: fact.summary || '',
+      projectId: fact.projectId ?? null,
+      categoryId: fact.categoryId ?? null,
+    });
+  }, []);
+
+  // 編集保存
+  const handleSaveEdit = useCallback(async (factId: string, parentId?: string) => {
+    if (isSaving) return;
+    setIsSaving(true);
+    try {
+      const res = await apiClient.patch(`/api/facts/${factId}`, {
+        title: editForm.title,
+        summary: editForm.summary || null,
+        projectId: editForm.projectId,
+        categoryId: editForm.categoryId,
+      });
+      const updated = res.data.data;
+
+      if (parentId) {
+        // 子 Fact の更新
+        setChildrenMap((prev) => ({
+          ...prev,
+          [parentId]: (prev[parentId] || []).map((c) => (c.id === factId ? { ...c, ...updated } : c)),
+        }));
+      } else {
+        setFacts((prev) => prev.map((f) => (f.id === factId ? { ...f, ...updated } : f)));
+      }
+
+      setEditingFactId(null);
+    } catch (error) {
+      console.error('Failed to update fact:', error);
+      toast({ title: '更新に失敗しました', status: 'error', duration: 5000, isClosable: true });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editForm, isSaving, toast]);
+
+  // 削除実行
+  const handleDelete = useCallback(async () => {
+    if (!deletingFact || isDeleting) return;
+    setIsDeleting(true);
+    try {
+      await apiClient.delete(`/api/facts/${deletingFact.id}`);
+
+      // 親 Fact かどうかで state 更新を分岐
+      const isParent = facts.some((f) => f.id === deletingFact.id);
+      if (isParent) {
+        setFacts((prev) => prev.filter((f) => f.id !== deletingFact.id));
+        setChildrenMap((prev) => {
+          const next = { ...prev };
+          delete next[deletingFact.id];
+          return next;
+        });
+      } else {
+        // 子 Fact の削除 → childrenMap から除去し、親の childCount を更新
+        let affectedParentId: string | null = null;
+        setChildrenMap((prev) => {
+          const next = { ...prev };
+          for (const [parentId, children] of Object.entries(next)) {
+            const filtered = children.filter((c) => c.id !== deletingFact.id);
+            if (filtered.length !== children.length) {
+              next[parentId] = filtered;
+              affectedParentId = parentId;
+            }
+          }
+          return next;
+        });
+        if (affectedParentId) {
+          setFacts((prevFacts) =>
+            prevFacts.map((f) =>
+              f.id === affectedParentId ? { ...f, childCount: (f.childCount ?? 1) - 1 } : f,
+            ),
+          );
+        }
+      }
+
+      setDeletingFact(null);
+    } catch (error) {
+      console.error('Failed to delete fact:', error);
+      toast({ title: '削除に失敗しました', status: 'error', duration: 5000, isClosable: true });
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deletingFact, isDeleting, facts, toast]);
 
   // 初回ロードとフィルター変更時のフェッチ
   useEffect(() => {
@@ -461,69 +573,164 @@ function FactsPageContent() {
                   >
                     <CardBody pb={grouped ? 0 : undefined}>
                       {/* 親 Fact */}
-                      <Flex justify="space-between" align="flex-start">
-                        <HStack spacing={3} align="flex-start" flex={1}>
-                          <Box
-                            w={1}
-                            minH="50px"
-                            borderRadius="full"
-                            bg={`${getSourceColor(fact.source)}.500`}
-                            flexShrink={0}
+                      {editingFactId === fact.id ? (
+                        /* インライン編集モード */
+                        <VStack spacing={3} align="stretch">
+                          <Input
+                            value={editForm.title}
+                            onChange={(e) => setEditForm((prev) => ({ ...prev, title: e.target.value }))}
+                            bg="gray.900"
+                            borderColor="gray.600"
+                            fontWeight="semibold"
+                            fontSize="lg"
+                            placeholder="タイトル"
                           />
-                          <Box flex={1}>
-                            <Text fontWeight="semibold" fontSize="lg" mb={1}>
-                              {fact.title}
-                            </Text>
-                            {fact.summary && (
-                              <Text fontSize="sm" color="gray.400" mb={2}>
-                                {fact.summary}
-                              </Text>
-                            )}
-                            <HStack spacing={2} flexWrap="wrap">
-                              <Badge
-                                colorScheme={getSourceColor(fact.source)}
-                                variant="subtle"
+                          <Textarea
+                            value={editForm.summary}
+                            onChange={(e) => setEditForm((prev) => ({ ...prev, summary: e.target.value }))}
+                            bg="gray.900"
+                            borderColor="gray.600"
+                            fontSize="sm"
+                            placeholder="サマリー（任意）"
+                            rows={2}
+                            resize="none"
+                          />
+                          <HStack spacing={2}>
+                            <Select
+                              size="sm"
+                              maxW="180px"
+                              bg="gray.900"
+                              borderColor="gray.600"
+                              value={editForm.categoryId ?? ''}
+                              onChange={(e) => setEditForm((prev) => ({ ...prev, categoryId: e.target.value || null }))}
+                            >
+                              <option value="">カテゴリなし</option>
+                              {categories.map((cat) => (
+                                <option key={cat.id} value={cat.id}>{cat.name}</option>
+                              ))}
+                            </Select>
+                            {projects.length > 0 && (
+                              <Select
+                                size="sm"
+                                maxW="220px"
+                                bg="gray.900"
+                                borderColor="gray.600"
+                                value={editForm.projectId ?? ''}
+                                onChange={(e) => setEditForm((prev) => ({ ...prev, projectId: e.target.value || null }))}
                               >
-                                {fact.source}
-                              </Badge>
-                              <Badge colorScheme="gray" variant="outline">
-                                {fact.type}
-                              </Badge>
-                              {fact.categoryId && (() => {
-                                const cat = categories.find((c) => c.id === fact.categoryId);
-                                return cat ? (
-                                  <Badge bg={cat.color} color="white" fontSize="xs">{cat.name}</Badge>
-                                ) : null;
-                              })()}
-                              {fact.projectId && (() => {
-                                const proj = projects.find((p) => p.id === fact.projectId);
-                                return proj ? (
-                                  <Badge colorScheme="cyan" variant="subtle" fontSize="xs">{proj.title}</Badge>
-                                ) : null;
-                              })()}
-                              <Text fontSize="xs" color="gray.500">
-                                {formatRelativeTime(fact.occurredAt)} (
-                                {formatDate(fact.occurredAt)})
+                                <option value="">プロジェクトなし</option>
+                                {projects.map((proj) => (
+                                  <option key={proj.id} value={proj.id}>{proj.title}</option>
+                                ))}
+                              </Select>
+                            )}
+                          </HStack>
+                          <HStack spacing={2}>
+                            <IconButton
+                              aria-label="保存"
+                              icon={<FiCheck />}
+                              colorScheme="green"
+                              size="sm"
+                              onClick={() => handleSaveEdit(fact.id)}
+                              isLoading={isSaving}
+                              isDisabled={!editForm.title.trim()}
+                            />
+                            <IconButton
+                              aria-label="キャンセル"
+                              icon={<FiX />}
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setEditingFactId(null)}
+                            />
+                          </HStack>
+                        </VStack>
+                      ) : (
+                        /* 通常表示モード */
+                        <Flex justify="space-between" align="flex-start">
+                          <HStack spacing={3} align="flex-start" flex={1}>
+                            <Box
+                              w={1}
+                              minH="50px"
+                              borderRadius="full"
+                              bg={`${getSourceColor(fact.source)}.500`}
+                              flexShrink={0}
+                            />
+                            <Box flex={1}>
+                              <Text fontWeight="semibold" fontSize="lg" mb={1}>
+                                {fact.title}
                               </Text>
-                            </HStack>
-                          </Box>
-                        </HStack>
+                              {fact.summary && (
+                                <Text fontSize="sm" color="gray.400" mb={2}>
+                                  {fact.summary}
+                                </Text>
+                              )}
+                              <HStack spacing={2} flexWrap="wrap">
+                                <Badge
+                                  colorScheme={getSourceColor(fact.source)}
+                                  variant="subtle"
+                                >
+                                  {fact.source}
+                                </Badge>
+                                <Badge colorScheme="gray" variant="outline">
+                                  {fact.type}
+                                </Badge>
+                                {fact.categoryId && (() => {
+                                  const cat = categories.find((c) => c.id === fact.categoryId);
+                                  return cat ? (
+                                    <Badge bg={cat.color} color="white" fontSize="xs">{cat.name}</Badge>
+                                  ) : null;
+                                })()}
+                                {fact.projectId && (() => {
+                                  const proj = projects.find((p) => p.id === fact.projectId);
+                                  return proj ? (
+                                    <Badge colorScheme="cyan" variant="subtle" fontSize="xs">{proj.title}</Badge>
+                                  ) : null;
+                                })()}
+                                <Text fontSize="xs" color="gray.500">
+                                  {formatRelativeTime(fact.occurredAt)} (
+                                  {formatDate(fact.occurredAt)})
+                                </Text>
+                              </HStack>
+                            </Box>
+                          </HStack>
 
-                        {fact.sourceUrl && (
-                          <Button
-                            as="a"
-                            href={fact.sourceUrl}
-                            target="_blank"
-                            size="sm"
-                            variant="ghost"
-                            colorScheme="gray"
-                            rightIcon={<Icon as={FiExternalLink} />}
-                            flexShrink={0}
-                          >
-                            開く
-                          </Button>
-                        )}
-                      </Flex>
+                          <HStack spacing={1} flexShrink={0}>
+                            {(fact.source === 'manual' || fact.source === 'comment') && (
+                              <>
+                                <IconButton
+                                  aria-label="編集"
+                                  icon={<FiEdit2 />}
+                                  size="sm"
+                                  variant="ghost"
+                                  colorScheme="gray"
+                                  onClick={() => startEditing(fact)}
+                                />
+                                <IconButton
+                                  aria-label="削除"
+                                  icon={<FiTrash2 />}
+                                  size="sm"
+                                  variant="ghost"
+                                  colorScheme="red"
+                                  onClick={() => setDeletingFact(fact)}
+                                />
+                              </>
+                            )}
+                            {fact.sourceUrl && (
+                              <Button
+                                as="a"
+                                href={fact.sourceUrl}
+                                target="_blank"
+                                size="sm"
+                                variant="ghost"
+                                colorScheme="gray"
+                                rightIcon={<Icon as={FiExternalLink} />}
+                              >
+                                開く
+                              </Button>
+                            )}
+                          </HStack>
+                        </Flex>
+                      )}
 
                       {/* スレッドバー */}
                       {grouped && (
@@ -595,36 +802,87 @@ function FactsPageContent() {
 
                                 {/* 子 Fact 内容 */}
                                 <Box flex={1} pb={idx < children.length - 1 ? 3 : 0}>
-                                  <Flex justify="space-between" align="flex-start">
-                                    <Box flex={1}>
-                                      <Text fontWeight="medium" fontSize="sm" color="gray.200">
-                                        {child.title}
-                                      </Text>
-                                      <HStack spacing={2} mt={1} flexWrap="wrap">
-                                        <Badge colorScheme="gray" variant="outline" fontSize="xs">
-                                          {child.type}
-                                        </Badge>
-                                        <Text fontSize="xs" color="gray.500">
-                                          {formatRelativeTime(child.occurredAt)}
-                                        </Text>
+                                  {editingFactId === child.id ? (
+                                    <VStack spacing={2} align="stretch">
+                                      <Input
+                                        value={editForm.title}
+                                        onChange={(e) => setEditForm((prev) => ({ ...prev, title: e.target.value }))}
+                                        bg="gray.900"
+                                        borderColor="gray.600"
+                                        size="sm"
+                                        placeholder="タイトル"
+                                      />
+                                      <HStack spacing={2}>
+                                        <IconButton
+                                          aria-label="保存"
+                                          icon={<FiCheck />}
+                                          colorScheme="green"
+                                          size="xs"
+                                          onClick={() => handleSaveEdit(child.id, fact.id)}
+                                          isLoading={isSaving}
+                                          isDisabled={!editForm.title.trim()}
+                                        />
+                                        <IconButton
+                                          aria-label="キャンセル"
+                                          icon={<FiX />}
+                                          variant="ghost"
+                                          size="xs"
+                                          onClick={() => setEditingFactId(null)}
+                                        />
                                       </HStack>
-                                    </Box>
-                                    {child.sourceUrl && (
-                                      <Button
-                                        as="a"
-                                        href={child.sourceUrl}
-                                        target="_blank"
-                                        size="xs"
-                                        variant="ghost"
-                                        colorScheme="gray"
-                                        rightIcon={<Icon as={FiExternalLink} boxSize={3} />}
-                                        flexShrink={0}
-                                        ml={2}
-                                      >
-                                        開く
-                                      </Button>
-                                    )}
-                                  </Flex>
+                                    </VStack>
+                                  ) : (
+                                    <Flex justify="space-between" align="flex-start">
+                                      <Box flex={1}>
+                                        <Text fontWeight="medium" fontSize="sm" color="gray.200">
+                                          {child.title}
+                                        </Text>
+                                        <HStack spacing={2} mt={1} flexWrap="wrap">
+                                          <Badge colorScheme="gray" variant="outline" fontSize="xs">
+                                            {child.type}
+                                          </Badge>
+                                          <Text fontSize="xs" color="gray.500">
+                                            {formatRelativeTime(child.occurredAt)}
+                                          </Text>
+                                        </HStack>
+                                      </Box>
+                                      <HStack spacing={0} flexShrink={0} ml={2}>
+                                        {(child.source === 'manual' || child.source === 'comment') && (
+                                          <>
+                                            <IconButton
+                                              aria-label="編集"
+                                              icon={<FiEdit2 />}
+                                              size="xs"
+                                              variant="ghost"
+                                              colorScheme="gray"
+                                              onClick={() => startEditing(child)}
+                                            />
+                                            <IconButton
+                                              aria-label="削除"
+                                              icon={<FiTrash2 />}
+                                              size="xs"
+                                              variant="ghost"
+                                              colorScheme="red"
+                                              onClick={() => setDeletingFact(child)}
+                                            />
+                                          </>
+                                        )}
+                                        {child.sourceUrl && (
+                                          <Button
+                                            as="a"
+                                            href={child.sourceUrl}
+                                            target="_blank"
+                                            size="xs"
+                                            variant="ghost"
+                                            colorScheme="gray"
+                                            rightIcon={<Icon as={FiExternalLink} boxSize={3} />}
+                                          >
+                                            開く
+                                          </Button>
+                                        )}
+                                      </HStack>
+                                    </Flex>
+                                  )}
                                 </Box>
                               </Flex>
                             ))}
@@ -752,6 +1010,37 @@ function FactsPageContent() {
           </Flex>
         </Box>
       </Flex>
+
+      {/* 削除確認ダイアログ */}
+      <AlertDialog
+        isOpen={!!deletingFact}
+        leastDestructiveRef={cancelDeleteRef as React.RefObject<HTMLButtonElement>}
+        onClose={() => setDeletingFact(null)}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent bg="gray.800" borderColor="gray.700" borderWidth="1px">
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Fact を削除
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              <Text>「{deletingFact?.title}」を削除しますか？</Text>
+              {deletingFact && (deletingFact.childCount ?? 0) > 0 && (
+                <Text color="orange.300" mt={2} fontSize="sm">
+                  スレッド内の {deletingFact.childCount} 件のコメントも削除されます。
+                </Text>
+              )}
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={cancelDeleteRef} onClick={() => setDeletingFact(null)} variant="ghost">
+                キャンセル
+              </Button>
+              <Button colorScheme="red" onClick={handleDelete} ml={3} isLoading={isDeleting}>
+                削除
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     </MainLayout>
   );
 }


### PR DESCRIPTION
## 概要
Issue #132: 登録済みの Fact を編集・削除できる機能を追加する。タイムライン上の各 Fact にアクションメニューを追加し、編集ダイアログと削除確認を実装する。

## 変更内容
```
apps/api/src/facts/dto/index.ts             |   1 +
 apps/api/src/facts/facts.controller.spec.ts |  27 +-
 apps/api/src/facts/facts.controller.ts      |  19 +-
 apps/api/src/facts/facts.service.spec.ts    | 131 +++++++-
 apps/api/src/facts/facts.service.ts         |  58 +++-
 apps/web/src/app/facts/page.tsx             | 465 ++++++++++++++++++++++------
 6 files changed, 607 insertions(+), 94 deletions(-)
```

## テスト結果
- テスト: **PASS**

<details><summary>テスト出力</summary>

```
全テスト合格です。

- **Test Suites:** 24 passed / 24 total
- **Tests:** 281 passed / 281 total

VERDICT: PASS
```
</details>

## レビュー
- Review: **REQUEST_CHANGES**

<details><summary>レビュー出力</summary>

```
## レビュー結果

### 完了条件チェック

| 条件 | 状態 |
|------|------|
| Fact の内容（テキスト・カテゴリ等）を編集できる UI | ✅ インライン編集モード実装済み |
| Fact を削除できる（確認ダイアログ付き） | ✅ AlertDialog で確認付き削除 |
| API（PATCH /facts/:id, DELETE /facts/:id） | ✅ Controller + Service 実装済み |
| 編集・削除後にタイムラインが正しく更新される | ✅ 親/子の state 更
```
</details>
