### PR TITLE
CI 失敗時に GitHub Issue を自動起票するワークフローを追加

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -1,0 +1,98 @@
+name: CI Failure Auto Issue
+
+# 主要 CI ワークフローが失敗したら、GitHub Issue を自動起票（またはコメント追加）する。
+# サイレント失敗を防ぐためのメタワークフロー。
+on:
+  workflow_run:
+    workflows:
+      - "API CI"
+      - "Web CI"
+      - "API Tests"
+      - "Web E2E Tests"
+      - "Security Scan"
+      - "Deploy"
+    types:
+      - completed
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  create-or-update-issue:
+    # 失敗時のみ実行。schedule / push / workflow_dispatch / pull_request どの event でも対象。
+    # ただし、pull_request 経由の失敗は PR 上のチェックで検知できるので除外（ノイズ低減）。
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find or create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const wfName = run.name;
+            const sha = (run.head_sha || '').slice(0, 7);
+            const branch = run.head_branch || '(unknown)';
+            const url = run.html_url;
+            const event = run.event;
+            const updatedAt = run.updated_at;
+
+            const titlePrefix = `[CI失敗] ${wfName}`;
+            const detail = [
+              '### 最新失敗',
+              `- workflow: \`${wfName}\``,
+              `- run: ${url}`,
+              `- branch: \`${branch}\``,
+              `- commit: \`${sha}\``,
+              `- event: \`${event}\``,
+              `- 検知時刻: ${updatedAt}`,
+            ].join('\n');
+
+            // 同 workflow の open Issue を探す（labels=ci-failure で絞り込み）
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-failure',
+              per_page: 100,
+            });
+            const matched = existing.find(i => i.title.startsWith(titlePrefix));
+
+            if (matched) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: matched.number,
+                body: `:rotating_light: 再発検知\n\n${detail}`,
+              });
+              core.info(`Commented on existing issue #${matched.number}`);
+              core.setOutput('action', 'commented');
+              core.setOutput('issue', matched.number);
+            } else {
+              const body = [
+                `**${wfName}** の CI が失敗しました（自動検知）。`,
+                '',
+                detail,
+                '',
+                '### 確認手順',
+                '1. 上記 run URL でログを確認',
+                '2. 失敗 job の原因を特定',
+                '3. 修正コミット or 設定変更で再実行',
+                '4. 解決したら本 Issue をクローズ（再発時は同 Issue にコメントが追加される）',
+                '',
+                '> 🤖 `.github/workflows/ci-failure-issue.yml` により自動起票',
+              ].join('\n');
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${titlePrefix} on ${branch}`,
+                body,
+                labels: ['bug', 'project:factrail', 'ci-failure'],
+              });
+              core.info(`Created issue #${created.number}`);
+              core.setOutput('action', 'created');
+              core.setOutput('issue', created.number);
+            }


### PR DESCRIPTION
## Summary
- 主要 CI（API CI / Web CI / API Tests / Web E2E Tests / Security Scan / Deploy）の失敗を検知し、Issue を自動起票するメタワークフロー追加
- 同 workflow の open Issue があればコメント追加で再発を記録、なければ新規起票
- PR 経由の失敗は除外（PR チェックで検知可能なため）

Fixes #159

## Test plan
- [ ] main マージ後、Security Scan の次回 schedule 実行（毎週日曜 0:00 UTC）で失敗が再発すれば Issue が自動起票されることを確認
- [ ] 同じ workflow で再度失敗した場合、新規 Issue ではなく既存 Issue にコメントが追加されることを確認
- [ ] 手動 workflow_dispatch で Security Scan を再実行することでも検証可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)