### PR TITLE
fix(deploy): deploy.sh を launchctl ベースに移行し runner の orphan cleanup 問題を解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,33 @@ name: Deploy
 on:
   push:
     branches: [main]
+  # 手動実行の口。runner は actions/checkout を使わずディスク上の deploy.sh を
+  # そのまま実行するため、deploy.sh を変更した push では「旧スクリプト」が走る
+  # （新スクリプトはその中の git pull で配置されるだけ）。新スクリプトを制御下で
+  # 初実行するために必要。service を指定すれば 1 サービスだけデプロイできる。
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'デプロイ対象サービス（空なら全部）'
+        required: false
+        default: ''
+
+# 2 本のデプロイが同時に kickstart を打つのを防ぐ
+concurrency:
+  group: deploy-factrail
+  cancel-in-progress: false
 
 jobs:
   deploy:
     name: Deploy to Mac mini
     runs-on: [self-hosted, deploy]
+    # ヘルスチェックが詰まった場合に runner を占有し続けないための保険
+    timeout-minutes: 20
     steps:
       - name: Deploy
         env:
           DEPLOY_ROOT: /Users/naoto/Projects/factrail
-        run: $DEPLOY_ROOT/scripts/deploy.sh
+          SERVICE: ${{ inputs.service }}
+        # $SERVICE はクォートしない（空なら引数なしで全サービスが対象になる）
+        run: |
+          "$DEPLOY_ROOT/scripts/deploy.sh" $SERVICE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,14 @@ on:
   workflow_dispatch:
     inputs:
       service:
-        description: 'デプロイ対象サービス（空なら全部）'
+        description: 'デプロイ対象サービス（all なら全部）'
         required: false
-        default: ''
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - api
+          - web
 
 # 2 本のデプロイが同時に kickstart を打つのを防ぐ
 concurrency:
@@ -30,6 +35,10 @@ jobs:
         env:
           DEPLOY_ROOT: /Users/naoto/Projects/factrail
           SERVICE: ${{ inputs.service }}
-        # $SERVICE はクォートしない（空なら引数なしで全サービスが対象になる）
+        # 'all'（既定）と push トリガ時の空文字はどちらも引数なし = 全サービスに落とす
         run: |
-          "$DEPLOY_ROOT/scripts/deploy.sh" $SERVICE
+          if [ -n "$SERVICE" ] && [ "$SERVICE" != "all" ]; then
+            "$DEPLOY_ROOT/scripts/deploy.sh" "$SERVICE"
+          else
+            "$DEPLOY_ROOT/scripts/deploy.sh"
+          fi

--- a/deploy.json
+++ b/deploy.json
@@ -6,8 +6,10 @@
       "dir": "apps/api",
       "port": 3001,
       "build_cmd": "pnpm run build",
-      "start_cmd": "pnpm run start",
-      "log_file": "~/Library/Logs/factrail-api.log",
+      "launchd_label": "com.sode.factrail-api",
+      "health_path": "/health",
+      "health_expect_jq": ".status == \"ok\"",
+      "health_timeout": 90,
       "error_log": "~/Library/Logs/factrail-api.error.log"
     },
     {
@@ -16,7 +18,10 @@
       "dir": "apps/web",
       "port": 3000,
       "build_cmd": "pnpm run build",
-      "start_cmd": "pnpm run start"
+      "launchd_label": "com.sode.factrail-web",
+      "health_path": "/",
+      "health_timeout": 60,
+      "error_log": "~/Library/Logs/factrail-web.error.log"
     }
   ]
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -242,6 +242,12 @@ apply_migrations() {
     return 0
   fi
 
+  # psql は migrations を使うサービスでのみ必要なので、無条件の依存チェックではなくここで見る
+  if ! command -v psql >/dev/null 2>&1; then
+    err "psql が必要です（$migrations_dir のマイグレーション適用に使用）"
+    return 1
+  fi
+
   configured=$(jq -r ".services[$idx].env_file // empty" "$DEPLOY_CONFIG")
 
   # 旧実装は「最初に存在したファイル」で break していたため、0 バイトの

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
-# 汎用デプロイスクリプト
-# deploy.json を読み取り、サービスのビルド・マイグレーション・再起動を行う
+# 汎用デプロイスクリプト（launchd 管理版）
+# deploy.json を読み取り、ビルド → launchctl kickstart → ヘルスチェックを行う。
 #
 # 使い方:
-#   ./scripts/deploy.sh          # 全サービスをデプロイ
-#   ./scripts/deploy.sh backend  # 指定サービスのみ
+#   ./scripts/deploy.sh                        # 全サービス
+#   ./scripts/deploy.sh web                    # 指定サービスのみ
+#   DEPLOY_SKIP_PULL=1 ./scripts/deploy.sh web # git pull を省略（ローカルリハーサル用）
 #
 # 前提:
-#   - deploy.json がリポジトリルートに存在
-#   - jq がインストール済み
-#   - .env がバックエンドディレクトリに存在（DB接続等）
+#   - deploy.json がリポジトリルートにあり、各サービスに launchd_label がある
+#   - 対象サービスが gui/$(id -u) ドメインに LaunchAgent としてロード済み
+#   - jq / curl / lsof / pgrep / launchctl が使える
+#
+# 設計メモ:
+#   - プロセスの停止・起動は一切行わない。launchd に kickstart を要求するだけ。
+#     これにより launchd の PGID 管理（AbandonProcessGroup=false）が効き、
+#     GitHub Actions runner の "Cleaning up orphan processes" の対象外になる。
+#     旧実装は lsof + kill + nohup でプロセスを直接起動していたため、
+#     ジョブ終了時に runner に殺され、起動成功判定が false positive になっていた。
+#   - 全処理を main() に閉じ込めてあるのは、実行中に git pull が本ファイルを
+#     差し替えても影響を受けないようにするため（bash はスクリプトを遅延読みする）。
+#   - bash 3.2 (macOS 標準) で動作すること。連想配列・mapfile は使えない。
 
 set -euo pipefail
 
@@ -17,44 +28,241 @@ REPO_ROOT="${DEPLOY_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 DEPLOY_CONFIG="$REPO_ROOT/deploy.json"
 TARGET_SERVICE="${1:-}"
 
-log() { echo "[deploy] $(date '+%H:%M:%S') $*"; }
-err() { echo "[deploy] ERROR: $*" >&2; }
+GUI_DOMAIN="gui/$(id -u)"
+SPAWN_TIMEOUT="${DEPLOY_SPAWN_TIMEOUT:-30}"   # kickstart → 新 PID 出現まで（ExitTimeOut 5 + ThrottleInterval 10 + 余裕）
+HEALTH_TIMEOUT="${DEPLOY_HEALTH_TIMEOUT:-90}" # kickstart → 健全判定まで
+POLL_INTERVAL=1                               # api の ThrottlerModule(short: 3req/1000ms) を踏まないため 1 秒固定
+MAX_RESPAWN=3                                 # ヘルス待ち中に許容する再起動回数（超えたらクラッシュループ）
 
-if [[ ! -f "$DEPLOY_CONFIG" ]]; then
-  err "deploy.json が見つかりません: $DEPLOY_CONFIG"
-  exit 1
-fi
+FAILED_SERVICES=""
 
-if ! command -v jq &>/dev/null; then
-  err "jq が必要です: brew install jq"
-  exit 1
-fi
+ts()   { date '+%H:%M:%S'; }
+log()  { echo "[deploy] $(ts) $*"; }
+warn() { echo "[deploy] $(ts) WARN:  $*" >&2; }
+err()  { echo "[deploy] $(ts) ERROR: $*" >&2; }
 
-# マイグレーション適用（未適用分のみ）
+# ---------------------------------------------------------------- launchd ヘルパ
+
+# launchctl print の "<field> = <value>" を 1 件取り出す（1 語のフィールドのみ）。
+# state は job / domain 等で複数回現れるため、最初の 1 件（= job のもの）を採る。
+launchd_field() {
+  local label="$1" field="$2"
+  launchctl print "$GUI_DOMAIN/$label" 2>/dev/null \
+    | awk -v f="$field" '$1 == f && $2 == "=" { print $3; exit }' \
+    || true
+}
+
+# サービスが gui ドメインに存在し print できるか。
+# 成功: rc=0 / 失敗: launchctl の生エラーメッセージを stdout に返し rc!=0
+launchd_probe() {
+  local label="$1"
+  # stdout（print の本文）は捨て、stderr のエラーメッセージだけを呼び出し元へ返す
+  { launchctl print "$GUI_DOMAIN/$label" >/dev/null; } 2>&1
+}
+
+# 失敗時の診断ダンプ
+dump_launchd_diag() {
+  local name="$1" label="$2" error_log="$3"
+  err "[$name] --- launchctl print $GUI_DOMAIN/$label ---"
+  launchctl print "$GUI_DOMAIN/$label" 2>&1 \
+    | grep -E '^[[:space:]]+(state|pid|runs|last exit code|program|working directory) =' >&2 || true
+  if [[ -n "$error_log" ]]; then
+    error_log="${error_log/#\~/$HOME}"
+    if [[ -f "$error_log" ]]; then
+      err "[$name] --- $error_log 末尾 30 行 ---"
+      tail -n 30 "$error_log" >&2 || true
+    fi
+  fi
+}
+
+# ------------------------------------------------------------ プロセス系統ヘルパ
+
+# 指定 PID の子孫（自身を含む）を空白区切りで出力する。
+# web は launchd 直下が `npm exec next start` で、実際に LISTEN するのはその子の
+# `next-server` なので、PID 一致判定ではなく子孫判定が必要。
+descendant_pids() {
+  local queue="$1" out="" pid children guard=0
+  while [[ -n "$queue" ]]; do
+    guard=$((guard + 1))
+    if [[ "$guard" -gt 200 ]]; then break; fi
+    pid="${queue%% *}"
+    case "$queue" in
+      *" "*) queue="${queue#* }" ;;
+      *)     queue="" ;;
+    esac
+    if [[ -z "$pid" ]]; then continue; fi
+    out="$out $pid"
+    children=$(pgrep -P "$pid" 2>/dev/null | tr '\n' ' ' || true)
+    if [[ -n "${children// /}" ]]; then
+      queue="$queue $children"
+    fi
+    queue=$(printf '%s' "$queue" | tr -s ' ' | sed -e 's/^ //' -e 's/ $//')
+  done
+  printf '%s' "$out" | tr -s ' ' | sed -e 's/^ //' -e 's/ $//'
+}
+
+pid_in_list() {
+  local needle="$1" p
+  shift
+  for p in "$@"; do
+    if [[ "$p" == "$needle" ]]; then return 0; fi
+  done
+  return 1
+}
+
+# ------------------------------------------------------------------- 再起動・検証
+# restart_service <name> <label> <port> <health_path> <expect_jq> <timeout> <error_log>
+restart_service() {
+  local name="$1" label="$2" port="$3" health_path="$4" expect_jq="$5" timeout="$6" error_log="$7"
+  local target="$GUI_DOMAIN/$label"
+  local runs_before pid_before ks_out ks_rc
+  local waited=0 elapsed=0 job_pid="" state="" last_reason=""
+  local runs_now respawns listen_pids desc stray p resp code body budget
+
+  runs_before=$(launchd_field "$label" runs); runs_before="${runs_before:-0}"
+  pid_before=$(launchd_field "$label" pid);   pid_before="${pid_before:-}"
+
+  log "[$name] 再起動: launchctl kickstart -kp $target  (再起動前 runs=$runs_before pid=${pid_before:-none})"
+
+  ks_rc=0
+  ks_out=$(launchctl kickstart -kp "$target" 2>&1) || ks_rc=$?
+  if [[ "$ks_rc" -ne 0 ]]; then
+    err "[$name] kickstart 失敗 (rc=$ks_rc): $ks_out"
+    dump_launchd_diag "$name" "$label" "$error_log"
+    return 1
+  fi
+  if [[ -n "$ks_out" ]]; then log "[$name] kickstart 出力: $ks_out"; fi
+
+  # --- 段 A: 新しいジョブ PID が現れるまで待つ ---
+  while [[ "$waited" -lt "$SPAWN_TIMEOUT" ]]; do
+    state=$(launchd_field "$label" state)
+    job_pid=$(launchd_field "$label" pid)
+    if [[ "$state" == "running" && -n "$job_pid" && "$job_pid" != "$pid_before" ]]; then
+      break
+    fi
+    job_pid=""
+    sleep "$POLL_INTERVAL"; waited=$((waited + POLL_INTERVAL))
+  done
+  if [[ -z "$job_pid" ]]; then
+    err "[$name] ${SPAWN_TIMEOUT}s 以内に新プロセスが起動しませんでした (state=${state:-unknown})"
+    err "[$name] ThrottleInterval=10 のため最大 10s 遅延しますが、それを超えています"
+    dump_launchd_diag "$name" "$label" "$error_log"
+    return 1
+  fi
+  log "[$name] launchd PID=$job_pid で spawn 確認 (${waited}s)"
+
+  # --- 段 B/C/D: クラッシュループ / 系統 / HTTP ---
+  budget=$((timeout - waited))
+  if [[ "$budget" -lt 10 ]]; then budget=10; fi
+
+  while [[ "$elapsed" -lt "$budget" ]]; do
+    # 段 B: クラッシュループ検出
+    runs_now=$(launchd_field "$label" runs); runs_now="${runs_now:-$runs_before}"
+    respawns=$((runs_now - runs_before - 1))
+    if [[ "$respawns" -ge "$MAX_RESPAWN" ]]; then
+      err "[$name] クラッシュループ検出: kickstart 後に ${respawns} 回再起動 (runs ${runs_before} → ${runs_now})"
+      dump_launchd_diag "$name" "$label" "$error_log"
+      return 1
+    fi
+
+    job_pid=$(launchd_field "$label" pid)
+    if [[ -z "$job_pid" ]]; then
+      last_reason="プロセス未起動（ThrottleInterval 待ちの可能性）"
+      sleep "$POLL_INTERVAL"; elapsed=$((elapsed + POLL_INTERVAL)); continue
+    fi
+
+    listen_pids=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | tr '\n' ' ' || true)
+    if [[ -z "${listen_pids// /}" ]]; then
+      last_reason="ポート $port が LISTEN されていない"
+      sleep "$POLL_INTERVAL"; elapsed=$((elapsed + POLL_INTERVAL)); continue
+    fi
+
+    # 段 C: 系統チェック（LISTEN 中の PID はすべて launchd ジョブの子孫であること）
+    # 孤児がポートを握っている場合、curl は孤児が応答して 200 を返すため、
+    # HTTP 判定だけでは false positive を除去できない。ここが本体。
+    desc=$(descendant_pids "$job_pid")
+    stray=""
+    for p in $listen_pids; do
+      if ! pid_in_list "$p" $desc; then stray="$stray $p"; fi
+    done
+    if [[ -n "$stray" ]]; then
+      err "[$name] ポート $port を launchd 管理外のプロセスが占有しています: PID$stray"
+      err "[$name] launchd ジョブ $label の PID=$job_pid / 子孫=[$desc]"
+      err "[$name] 旧 nohup デプロイが残した孤児の可能性が高い。確認してください:"
+      err "[$name]   ps -o pid,ppid,pgid,lstart,command -p$(printf '%s' "$stray" | tr ' ' ',' | sed 's/^,//')"
+      dump_launchd_diag "$name" "$label" "$error_log"
+      return 1
+    fi
+
+    # 段 D: HTTP（1 ポーリング 1 リクエスト。ThrottlerModule short=3req/1s に対し 1req/s）
+    resp=$(curl -s -m 5 -w '\n%{http_code}' "http://localhost:${port}${health_path}" 2>/dev/null || true)
+    code="${resp##*$'\n'}"; code="${code:-000}"
+    body="${resp%$'\n'*}"
+
+    case "$code" in
+      2*)
+        if [[ -z "$expect_jq" ]]; then
+          log "[$name] 起動成功: PID=$job_pid port=$port HTTP=$code  (kickstart から $((waited + elapsed))s)"
+          return 0
+        fi
+        if printf '%s' "$body" | jq -e "$expect_jq" >/dev/null 2>&1; then
+          log "[$name] 起動成功: PID=$job_pid port=$port HTTP=$code  (kickstart から $((waited + elapsed))s)"
+          return 0
+        fi
+        # /health は DB 断でも HTTP 200 を返し body だけ "degraded" になる
+        last_reason="HTTP $code だが期待条件 '$expect_jq' を満たさない: $(printf '%s' "$body" | head -c 200)"
+        ;;
+      429)
+        last_reason="HTTP 429 (ThrottlerModule) — バックオフして再試行"
+        sleep 2; elapsed=$((elapsed + 2))
+        ;;
+      000)
+        last_reason="接続できない（起動途中の可能性）"
+        ;;
+      *)
+        last_reason="HTTP $code"
+        ;;
+    esac
+    sleep "$POLL_INTERVAL"; elapsed=$((elapsed + POLL_INTERVAL))
+  done
+
+  err "[$name] ${timeout}s 以内に健全になりませんでした: ${last_reason:-理由不明}"
+  dump_launchd_diag "$name" "$label" "$error_log"
+  return 1
+}
+
+# ------------------------------------------------------------------ マイグレーション
 apply_migrations() {
-  local migrations_dir="$1"
+  local idx="$1" migrations_dir="$2"
   local full_path="$REPO_ROOT/$migrations_dir"
+  local db_url="" env_file="" cand configured applied=0 sql_file filename exists
 
   if [[ ! -d "$full_path" ]]; then
     log "マイグレーションディレクトリなし: $migrations_dir"
     return 0
   fi
 
-  # .env から DATABASE_URL を読み取り
-  local db_url=""
-  for env_file in "$REPO_ROOT/.env" "$REPO_ROOT/backend/.env"; do
-    if [[ -f "$env_file" ]]; then
-      db_url=$(grep '^DATABASE_URL=' "$env_file" | head -1 | cut -d= -f2-)
-      break
-    fi
+  configured=$(jq -r ".services[$idx].env_file // empty" "$DEPLOY_CONFIG")
+
+  # 旧実装は「最初に存在したファイル」で break していたため、0 バイトの
+  # $REPO_ROOT/.env に当たって apps/api/.env に到達できなかった。
+  # → DATABASE_URL が取れたときだけ break する。
+  for cand in ${configured:+"$REPO_ROOT/$configured"} \
+              "$REPO_ROOT/apps/api/.env" \
+              "$REPO_ROOT/backend/.env" \
+              "$REPO_ROOT/.env"; do
+    if [[ ! -f "$cand" ]]; then continue; fi
+    db_url=$(grep -E '^DATABASE_URL=' "$cand" 2>/dev/null | head -1 | cut -d= -f2- \
+             | sed -e 's/^"//' -e "s/^'//" -e 's/"$//' -e "s/'$//")
+    if [[ -n "$db_url" ]]; then env_file="$cand"; break; fi
   done
 
   if [[ -z "$db_url" ]]; then
-    err "DATABASE_URL が見つかりません"
+    err "DATABASE_URL が見つかりません（探索: ${configured:+$configured, }apps/api/.env, backend/.env, .env）"
     return 1
   fi
+  log "DATABASE_URL を $env_file から読み込み"
 
-  # migration_history テーブルを作成（なければ）
   psql "$db_url" -c "
     CREATE TABLE IF NOT EXISTS migration_history (
       filename TEXT PRIMARY KEY,
@@ -62,18 +270,12 @@ apply_migrations() {
     );
   " &>/dev/null
 
-  local applied=0
   for sql_file in "$full_path"/*.sql; do
-    [[ ! -f "$sql_file" ]] && continue
-    local filename
+    if [[ ! -f "$sql_file" ]]; then continue; fi
     filename=$(basename "$sql_file")
 
-    # 適用済みかチェック
-    local exists
     exists=$(psql "$db_url" -tAc "SELECT 1 FROM migration_history WHERE filename = '$filename';" 2>/dev/null || echo "")
-    if [[ "$exists" == "1" ]]; then
-      continue
-    fi
+    if [[ "$exists" == "1" ]]; then continue; fi
 
     log "マイグレーション適用: $filename"
     if psql "$db_url" -f "$sql_file" &>/dev/null; then
@@ -90,161 +292,157 @@ apply_migrations() {
   else
     log "新規マイグレーションなし"
   fi
+  return 0
 }
 
-# プロセス停止
-stop_service() {
-  local port="$1"
-  local pids
-  pids=$(lsof -ti ":$port" 2>/dev/null || true)
-  if [[ -n "$pids" ]]; then
-    log "ポート $port のプロセスを停止: $pids"
-    echo "$pids" | xargs kill 2>/dev/null || true
-    sleep 2
-    # まだ残っていたら強制終了
-    pids=$(lsof -ti ":$port" 2>/dev/null || true)
-    if [[ -n "$pids" ]]; then
-      echo "$pids" | xargs kill -9 2>/dev/null || true
-      sleep 1
-    fi
-  fi
-}
+# ------------------------------------------------------------------ サービス単位
+deploy_service() {
+  local i="$1"
+  local name type dir port build_cmd label health_path expect_jq timeout error_log migrations_dir
 
-# Rust サービスのデプロイ
-deploy_rust() {
-  local name="$1" dir="$2" port="$3" build_cmd="$4" binary="$5" log_file="$6" error_log="$7"
-
-  log "[$name] ビルド開始"
-  local service_dir="$REPO_ROOT/$dir"
-  (cd "$service_dir" && eval "$build_cmd") || { err "[$name] ビルド失敗"; return 1; }
-  log "[$name] ビルド完了"
-
-  stop_service "$port"
-
-  # expand ~ in log paths
-  log_file="${log_file/#\~/$HOME}"
-  error_log="${error_log/#\~/$HOME}"
-  mkdir -p "$(dirname "$log_file")"
-
-  log "[$name] 起動: ポート $port"
-  (cd "$REPO_ROOT/$dir" && nohup "$REPO_ROOT/$dir/$binary" >> "$log_file" 2>> "$error_log" &)
-  sleep 2
-
-  if lsof -ti ":$port" &>/dev/null; then
-    log "[$name] 起動成功"
-  else
-    err "[$name] 起動失敗 — ログを確認: $error_log"
-    return 1
-  fi
-}
-
-# Next.js サービスのデプロイ
-deploy_nextjs() {
-  local name="$1" dir="$2" port="$3" build_cmd="$4" start_cmd="$5"
-
-  local service_dir="$REPO_ROOT/$dir"
-
-  log "[$name] ビルド開始"
-  (cd "$service_dir" && eval "$build_cmd") || { err "[$name] ビルド失敗"; return 1; }
-  log "[$name] ビルド完了"
-
-  stop_service "$port"
-
-  log "[$name] 起動: ポート $port"
-  (cd "$service_dir" && nohup $start_cmd > /dev/null 2>&1 &)
-  sleep 5
-
-  if lsof -ti ":$port" &>/dev/null; then
-    log "[$name] 起動成功"
-  else
-    err "[$name] 起動失敗"
-    return 1
-  fi
-}
-
-# Node.js サービスのデプロイ（NestJS等）
-deploy_node() {
-  local name="$1" dir="$2" port="$3" build_cmd="$4" start_cmd="$5" log_file="$6" error_log="$7"
-
-  local service_dir="$REPO_ROOT/$dir"
-
-  log "[$name] ビルド開始"
-  (cd "$service_dir" && eval "$build_cmd") || { err "[$name] ビルド失敗"; return 1; }
-  log "[$name] ビルド完了"
-
-  stop_service "$port"
-
-  log_file="${log_file/#\~/$HOME}"
-  error_log="${error_log/#\~/$HOME}"
-  mkdir -p "$(dirname "$log_file")"
-
-  log "[$name] 起動: ポート $port"
-  (cd "$service_dir" && nohup $start_cmd >> "$log_file" 2>> "$error_log" &)
-  sleep 3
-
-  if lsof -ti ":$port" &>/dev/null; then
-    log "[$name] 起動成功"
-  else
-    err "[$name] 起動失敗 — ログを確認: $error_log"
-    return 1
-  fi
-}
-
-# メイン処理
-log "デプロイ開始: $(basename "$REPO_ROOT")"
-
-# git pull
-log "最新コードを取得"
-(cd "$REPO_ROOT" && git pull origin main --ff-only) || { err "git pull 失敗"; exit 1; }
-
-# 依存パッケージをインストール（pnpm workspace でルートから一括）
-log "依存パッケージをインストール"
-(cd "$REPO_ROOT" && pnpm install --frozen-lockfile) || { err "pnpm install 失敗"; exit 1; }
-
-# サービスをループ
-service_count=$(jq '.services | length' "$DEPLOY_CONFIG")
-
-for i in $(seq 0 $((service_count - 1))); do
   name=$(jq -r ".services[$i].name" "$DEPLOY_CONFIG")
   type=$(jq -r ".services[$i].type" "$DEPLOY_CONFIG")
-
-  # 特定サービス指定時はスキップ
-  if [[ -n "$TARGET_SERVICE" && "$name" != "$TARGET_SERVICE" ]]; then
-    continue
-  fi
-
-  # マイグレーション
-  migrations_dir=$(jq -r ".services[$i].migrations_dir // empty" "$DEPLOY_CONFIG")
-  if [[ -n "$migrations_dir" ]]; then
-    apply_migrations "$migrations_dir"
-  fi
-
-  # タイプ別デプロイ
   dir=$(jq -r ".services[$i].dir" "$DEPLOY_CONFIG")
   port=$(jq -r ".services[$i].port" "$DEPLOY_CONFIG")
-  build_cmd=$(jq -r ".services[$i].build_cmd" "$DEPLOY_CONFIG")
+  build_cmd=$(jq -r ".services[$i].build_cmd // empty" "$DEPLOY_CONFIG")
+  label=$(jq -r ".services[$i].launchd_label // empty" "$DEPLOY_CONFIG")
+  health_path=$(jq -r ".services[$i].health_path // \"/\"" "$DEPLOY_CONFIG")
+  expect_jq=$(jq -r ".services[$i].health_expect_jq // empty" "$DEPLOY_CONFIG")
+  timeout=$(jq -r ".services[$i].health_timeout // empty" "$DEPLOY_CONFIG"); timeout="${timeout:-$HEALTH_TIMEOUT}"
+  error_log=$(jq -r ".services[$i].error_log // empty" "$DEPLOY_CONFIG")
+  migrations_dir=$(jq -r ".services[$i].migrations_dir // empty" "$DEPLOY_CONFIG")
 
+  # 旧実装は未対応タイプを err だけ出して成功扱いにしていた。ここで必ず失敗させる。
   case "$type" in
-    rust)
-      binary=$(jq -r ".services[$i].binary" "$DEPLOY_CONFIG")
-      log_file=$(jq -r ".services[$i].log_file // \"/tmp/${name}.log\"" "$DEPLOY_CONFIG")
-      error_log=$(jq -r ".services[$i].error_log // \"/tmp/${name}.error.log\"" "$DEPLOY_CONFIG")
-      deploy_rust "$name" "$dir" "$port" "$build_cmd" "$binary" "$log_file" "$error_log"
-      ;;
-    nextjs)
-      start_cmd=$(jq -r ".services[$i].start_cmd" "$DEPLOY_CONFIG")
-      deploy_nextjs "$name" "$dir" "$port" "$build_cmd" "$start_cmd"
-      ;;
-    node)
-      start_cmd=$(jq -r ".services[$i].start_cmd" "$DEPLOY_CONFIG")
-      log_file=$(jq -r ".services[$i].log_file // \"/tmp/${name}.log\"" "$DEPLOY_CONFIG")
-      error_log=$(jq -r ".services[$i].error_log // \"/tmp/${name}.error.log\"" "$DEPLOY_CONFIG")
-      deploy_node "$name" "$dir" "$port" "$build_cmd" "$start_cmd" "$log_file" "$error_log"
-      ;;
-    *)
-      err "未対応のタイプ: $type"
-      ;;
+    node|nextjs|rust) : ;;
+    *) err "[$name] 未対応のタイプ: $type"; return 1 ;;
   esac
-done
 
-log "デプロイ完了"
+  if [[ -z "$label" ]]; then
+    err "[$name] deploy.json に launchd_label がありません"
+    return 1
+  fi
+
+  if [[ -n "$migrations_dir" ]]; then
+    if ! apply_migrations "$i" "$migrations_dir"; then
+      err "[$name] マイグレーション失敗"
+      return 1
+    fi
+  fi
+
+  if [[ -n "$build_cmd" ]]; then
+    log "[$name] ビルド開始: ($dir) $build_cmd"
+    if ! (cd "$REPO_ROOT/$dir" && eval "$build_cmd"); then
+      err "[$name] ビルド失敗（サービスは旧バージョンのまま稼働継続）"
+      return 1
+    fi
+    log "[$name] ビルド完了"
+  fi
+
+  restart_service "$name" "$label" "$port" "$health_path" "$expect_jq" "$timeout" "$error_log"
+}
+
+# ------------------------------------------------------------------ プリフライト
+# git pull もビルドも再起動も行う前に、launchctl が使えるかだけを read-only で確かめる。
+# ここで落ちた場合、リポジトリもサービスも一切変更されていない＝ダウンタイム 0。
+preflight() {
+  local count i name label msg bad=0
+  count=$(jq '.services | length' "$DEPLOY_CONFIG")
+  # 変数展開の直後に全角文字が来ると bash が変数名の一部と解釈するため ${} で明示的に閉じる
+  log "launchd プリフライト（ドメイン: ${GUI_DOMAIN}）"
+  for i in $(seq 0 $((count - 1))); do
+    name=$(jq -r ".services[$i].name" "$DEPLOY_CONFIG")
+    if [[ -n "$TARGET_SERVICE" && "$name" != "$TARGET_SERVICE" ]]; then continue; fi
+
+    label=$(jq -r ".services[$i].launchd_label // empty" "$DEPLOY_CONFIG")
+    if [[ -z "$label" ]]; then
+      err "  NG  [$name] launchd_label が deploy.json にありません"
+      bad=1; continue
+    fi
+
+    if msg=$(launchd_probe "$label"); then
+      log "  OK  $label"
+      continue
+    fi
+
+    err "  NG  $label: ${msg:-（メッセージなし）}"
+    # 注: "Bad request." はサービス未登録でもドメイン到達不能でも出るため、
+    #     より具体的な "Could not find service" を先に判定する。
+    case "$msg" in
+      *"Could not find service"*)
+        err "      → LaunchAgent が未ロード、またはラベル名が誤っています:"
+        err "         launchctl list | grep ${label}"
+        err "         launchctl bootstrap ${GUI_DOMAIN} ~/Library/LaunchAgents/${label}.plist"
+        ;;
+      *"Could not find domain"*|*"Bootstrap failed"*|*"Input/output error"*|*"Operation not permitted"*)
+        err "      → ${GUI_DOMAIN} ドメイン自体に到達できません。"
+        err "      → runner plist の SessionCreate=true が原因の可能性が高いです。"
+        err "      → 対処: ~/Library/LaunchAgents/actions.runner.sode0417-factrail.mac-mini-factrail.plist"
+        err "              の SessionCreate を false にして runner を再ロードしてください。"
+        ;;
+      *)
+        err "      → 想定外のエラーです。上のメッセージを確認してください。"
+        ;;
+    esac
+    bad=1
+  done
+  if [[ "$bad" -ne 0 ]]; then return 1; fi
+  return 0
+}
+
+# ------------------------------------------------------------------------ main
+main() {
+  local c service_count i name matched=0
+
+  if [[ ! -f "$DEPLOY_CONFIG" ]]; then err "deploy.json が見つかりません: $DEPLOY_CONFIG"; exit 1; fi
+  for c in jq curl lsof pgrep launchctl; do
+    if ! command -v "$c" >/dev/null 2>&1; then err "$c が必要です"; exit 1; fi
+  done
+
+  log "デプロイ開始: $(basename "$REPO_ROOT")${TARGET_SERVICE:+ (target: $TARGET_SERVICE)}"
+
+  # 0) launchd プリフライト（何も変更しないうちに検査する）
+  if ! preflight; then
+    err "launchd プリフライトに失敗。リポジトリもサービスも変更していません（サービスは旧バージョンで稼働継続）。"
+    exit 1
+  fi
+
+  # 1) git pull
+  if [[ "${DEPLOY_SKIP_PULL:-0}" == "1" ]]; then
+    log "DEPLOY_SKIP_PULL=1 のため git pull をスキップ"
+  else
+    log "最新コードを取得"
+    if ! (cd "$REPO_ROOT" && git pull origin main --ff-only); then err "git pull 失敗"; exit 1; fi
+  fi
+  log "HEAD: $(cd "$REPO_ROOT" && git log -1 --pretty='%h %s')"
+
+  # 2) 依存
+  log "依存パッケージをインストール"
+  if ! (cd "$REPO_ROOT" && pnpm install --frozen-lockfile); then err "pnpm install 失敗"; exit 1; fi
+
+  # 3) サービスループ（1 つ失敗しても後続を続ける）
+  service_count=$(jq '.services | length' "$DEPLOY_CONFIG")
+  for i in $(seq 0 $((service_count - 1))); do
+    name=$(jq -r ".services[$i].name" "$DEPLOY_CONFIG")
+    if [[ -n "$TARGET_SERVICE" && "$name" != "$TARGET_SERVICE" ]]; then continue; fi
+    matched=1
+    if ! deploy_service "$i"; then
+      FAILED_SERVICES="$FAILED_SERVICES $name"
+    fi
+  done
+
+  if [[ -n "$TARGET_SERVICE" && "$matched" -eq 0 ]]; then
+    err "deploy.json にサービス '$TARGET_SERVICE' がありません"
+    exit 1
+  fi
+
+  if [[ -n "$FAILED_SERVICES" ]]; then
+    err "デプロイ失敗:$FAILED_SERVICES"
+    exit 1
+  fi
+  log "デプロイ完了"
+}
+
+# 実行中に git pull が本ファイルを差し替えてもパース済みで影響を受けないよう、
+# 全処理を main() に閉じ込めて最終行で呼ぶ。
+main "$@"


### PR DESCRIPTION
## 背景

PR #168 の作業中に Slack の「デプロイ一部失敗」通知を追ったところ、通知自体は deploy-hook の設定漏れ（対応済み）でしたが、その過程で**より深い構造欠陥**が判明しました。

`scripts/deploy.sh` は `launchctl` を使わず `lsof -ti :PORT | xargs kill` → `nohup pnpm run start &` でプロセスを起動します。しかし **GitHub Actions runner はジョブ終了時の `Cleaning up orphan processes` でその nohup プロセスを必ず Terminate します**。成功判定は起動 3〜5 秒後の `lsof` なので、殺される前に「成功」と出てしまう — つまり **Actions の success は false positive** でした。

実際の run 30193203824 のログ:

```
07:40:28  [deploy] [web] 起動: ポート 3000
07:40:33  [deploy] [web] 起動成功            ← lsof が通っただけ
07:40:33  [deploy] デプロイ完了              ← Actions は success
07:40:38  Cleaning up orphan processes
07:40:39  Terminate orphan process: pid (39311) (node)   ← 殺されている
```

子プロセスが孤児化して残ると launchd 側が `EADDRINUSE` で永久リトライに入ります。実測値:

| 指標 | 実測 |
|---|---|
| `com.sode.factrail-web` の再起動回数 | **1,254 回** |
| `factrail-web.error.log` の EADDRINUSE | **1,274,223 行** |
| `factrail-api.log` | **1.26 GiB**（99.76% が 3〜4 月のクラッシュループ痕） |
| 本日 16:40〜17:05 | **25 分間ループ**（手動介入で解消） |

## 対応方針

**launchd を唯一のプロセス管理者にする。** 決め手は `AbandonProcessGroup` が既定 `false` であることです。`man launchd.plist` に「ジョブが死ぬと launchd は同じ PGID のプロセスを kill する」とあり、**launchd 経由なら孫プロセスの残留が構造的に起きません**。

## 変更内容

### `scripts/deploy.sh`

- **`stop_service()` を関数ごと撤去** — `kickstart -k` が停止と起動を原子的に行うため「止めてから起動」という手順自体が不要に。加えて旧実装の `lsof -ti ":$port"` は `-sTCP:LISTEN` がなく **ESTABLISHED なども拾って無関係なプロセスを殺しうる**書き方でした
- **`deploy_rust` / `deploy_nextjs` / `deploy_node` を `deploy_service()` に統合** — 3 者の差分（`start_cmd` / `binary` / nohup のリダイレクト先）はすべて plist の関心事に移るため、統合すると完全に同一になります
- **4 段ヘルスチェック**を導入

| 段 | 検査 |
|---|---|
| A | 新しいジョブ PID の出現を待つ（`ThrottleInterval=10` の遅延を吸収） |
| B | `runs` の増分監視でクラッシュループを検出 |
| **C** | **LISTEN 中の PID が launchd ジョブの子孫か検証** |
| D | HTTP と body の `jq` 判定 |

**段 C が要です。** 孤児がポートを握っている状態では **`curl` は孤児が応答して 200 を返す**ため、HTTP 判定だけでは false positive を除去できません。今日実際に起きた状態がまさにこれでした。

- **launchctl プリフライトを全処理の最前段に配置** — runner plist の `SessionCreate=true` でドメインに到達できない場合、**`git pull` もビルドも再起動も実行せずに落ちます**（＝無変更・無停止でサービスは旧版のまま稼働）。フォールバックは実装していません（フォールバック先が今まさに撤去しようとしているバグそのもので、最もデバッグしづらい環境でだけ発動するため）
- **サービス単位で失敗を収集して最後に集約** — api の失敗で web が飛ばなくなります
- **全処理を `main()` に閉じ込め** — 実行中に `git pull` が本ファイルを差し替えても影響を受けません
- `apply_migrations` の `.env` 探索が **0 バイトの `$REPO_ROOT/.env`** で打ち切られ `apps/api/.env` に到達できなかったバグを修正
- 未対応 `type` が警告のみで**成功扱い**になっていた問題を修正

なお macOS 標準の bash は 3.2.57 なので、連想配列を使わず文字列ベースで実装しています。

### `deploy.json`

`launchd_label` / `health_path` / `health_expect_jq` / `health_timeout` を追加し、**`start_cmd` と `log_file` を削除**しました。起動は plist の `ProgramArguments`、ログは `StandardOutPath` が唯一の権威になります。これで「plist は `-p 3000` 明示、JSON は `pnpm run start`（ポート指定なし）」という二重管理も解消されます。

ラベルは規約導出ではなく**明示指定**にしています。f2a では `name: "web"` ↔ `com.sode.f2a-frontend` と規約から外れており、導出は「存在しないがそれっぽいラベル」を生んで破綻するためです。

### `.github/workflows/deploy.yml`

**`workflow_dispatch` の追加が必須でした。** runner は `actions/checkout` を使わず**ディスク上の `deploy.sh` をそのまま実行**するため、この PR をマージした push で走るのは**旧スクリプト**です（新スクリプトはその中の `git pull` で配置されるだけ）。手動起動の口がないと新スクリプトを制御下で初実行できません。

併せて `concurrency`（2 本同時の kickstart 防止）と `timeout-minutes: 20` も追加しました。

### plist は 1 バイトも変更していません

`HOME` の欠落は `ps -Eww` で実際には注入されていることを確認済み、`ThrottleInterval=10` はログ肥大の真因ではないため据え置きです。**これにより切り戻しが「2 ファイルを git で戻すだけ」で完結し、launchd 状態の巻き戻しが不要**になります。

## 手元検証（本番 Mac mini でリハーサル実施済み）

`DEPLOY_SKIP_PULL=1 ./scripts/deploy.sh <service>` で実際にデプロイしました。

| | web | api |
|---|---|---|
| kickstart → HTTP 200 | **1 秒** | **2 秒** |
| body 判定 | — | ✅ `{"status":"ok"}` |
| `runs` の増分 | 1254 → **1255（+1）** | 13 → **14（+1）** |
| **error.log の増分** | **0 行** | **0 行** |
| LISTEN 主 | PID 59907（PPID/PGID = 59873 = ジョブ PID） | PID 60160（ジョブ PID そのもの） |

**`error.log` の増分がゼロ**という点が重要です。旧実装では毎回デプロイのたびに数千行の EADDRINUSE が出ていました。

**異常系**も確認済み:
- 存在しないラベル → **`git pull` もビルドも走らずに exit 1**、診断メッセージも正しく分岐（「ラベル未ロード」と「ドメイン到達不能」を区別）
- `bash -n`（3.2 で）と `shellcheck -S warning` を通過（指摘ゼロ）

## マージ後の手順（重要）

「1 回遅れ」問題があるため、次の順で進める必要があります:

1. **マージ** → 旧スクリプトが最後に 1 回走る（孤児が出る前提）
2. Mac mini で `git pull` を確実化し、新スクリプトの配置を確認
3. 旧スクリプトが残した孤児を掃除して `launchctl kickstart -k` で整地
4. **`workflow_dispatch` を `service: web` で手動起動** ← 新スクリプトの初実行。web だけなら失敗しても API は無傷
5. 成功したら全体を手動起動

### 唯一の未検証点

runner plist の `SessionCreate = true` により、runner のコンテキストから `launchctl kickstart gui/501/...` が通るかは**実際に Actions を走らせるまで確定しません**。ただしプリフライトにより、**失敗しても無変更・無停止**（Actions が赤くなるだけ）で止まります。

詰まった場合の対処: ① runner plist の `SessionCreate` を false にして再ロード ② deploy-hook (:3090) を再起動役に使う（deploy-hook 自身が gui/501 の LaunchAgent なので launchctl が確実に通る）。

## 横展開は今回やりません

同じ `deploy.sh` は f2a / ai-dev-team にもありますが、factrail で数回のデプロイサイクルを回してから着手します。理由:

- **f2a は現在ビルドすらしていない** — `skip_restart` 判定が build より前で `continue` し、全 3 サービスが `skip_restart: true`。launchctl 化には `skip_restart` 撤廃とビルド復活が伴い、別案件の規模
- **ai-dev-team はポート定義が矛盾** — `deploy.json` は 8100/3100 だが `health-check.sh` は 3030/3031

## フォローアップ

- `~/Library/Logs/factrail-*.log` の 1.5 GB 回収とローテーション導入（本改修でクラッシュループ由来の増加は止まりますが、既存分は残ります）
- `CLAUDE.md` / `README.md` / `context.md` / `quickref.md` のデプロイ記述の是正（`quickref.md` には `railway up` / `vercel deploy` が実行可能なコマンドとして残っています）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
