### PR TITLE
docs: デプロイ機構の記述を実態に合わせる（Railway/Vercel と npm 前提を一掃）

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -52,10 +52,15 @@ factrail/
   - アクティビティビュー
 
 #### Infrastructure
-- **Database**: Supabase (PostgreSQL)
-- **API Deploy**: Railway
-- **Web Deploy**: Vercel
-- **Queue**: Redis (Bull)
+- **Database**: Supabase (PostgreSQL) - multiSchema: factrail, public
+- **Hosting**: Mac mini（自宅サーバ）+ Cloudflare Tunnel
+  - API: `factrail-api.sode-ai.com` → localhost:3001
+  - Web: `factrail.sode-ai.com` → localhost:3000
+- **プロセス常駐**: launchd（`com.sode.factrail-api` / `com.sode.factrail-web`、KeepAlive + ThrottleInterval 10）
+- **Deploy**: GitHub Actions self-hosted runner `mac-mini-factrail` → `scripts/deploy.sh`（`main` push で自動）
+  - ※ Railway / Vercel は 2026-03-15 に廃止し Mac mini へ全面移行
+- **Queue**: Redis (Bull) — Homebrew Redis :6379
+- **パッケージマネージャ**: pnpm workspace（2026-04-05 に npm から移行）
 
 ## データモデル
 
@@ -380,10 +385,11 @@ npm run test:cov
 ## リポジトリ情報
 
 - **Main branch**: main
-- **Current branch**: claude/issue-4-slack-dm-dispatch
-- **最新機能**: Slack DM/チャンネル自動投稿機能の実装完了
-- **Railway**: apps/api をデプロイ
-- **Vercel**: apps/web をデプロイ予定
+- **デプロイ**: `main` への push → `deploy.yml` → self-hosted runner `mac-mini-factrail` → `scripts/deploy.sh`
+  - `deploy.json` に定義: `api`（node / apps/api / :3001）, `web`（nextjs / apps/web / :3000）
+  - ビルドは `pnpm run build`、起動は launchd（`launchctl kickstart -kp`）に委譲
+- **常駐**: launchd `com.sode.factrail-api`, `com.sode.factrail-web`
+- Railway / Vercel は **2026-03-15 に廃止**（Mac mini + Cloudflare Tunnel へ移行）
 
 ## 主要ファイルパス
 

--- a/.claude/quickref.md
+++ b/.claude/quickref.md
@@ -5,14 +5,9 @@
 ### プロジェクトのセットアップ
 
 ```bash
-# 依存関係インストール
-npm install
-
-# API依存関係インストール
-cd apps/api && npm install
-
-# Web依存関係インストール
-cd apps/web && npm install
+# 依存関係インストール（pnpm workspace のためルートで一括。
+# apps/api や apps/web で個別に実行する必要はない）
+pnpm install
 
 # 環境変数設定
 cp apps/api/.env.example apps/api/.env
@@ -24,11 +19,11 @@ cp apps/api/.env.example apps/api/.env
 ```bash
 # API開発サーバー起動（ポート3001）
 cd apps/api
-npm run start:dev
+pnpm run start:dev
 
 # Web開発サーバー起動（ポート3000）
 cd apps/web
-npm run dev
+pnpm run dev
 ```
 
 ### データベース操作
@@ -75,29 +70,41 @@ git push -u origin <branch-name>
 ```bash
 # ユニットテスト実行
 cd apps/api
-npm run test
+pnpm run test
 
 # E2Eテスト実行
-npm run test:e2e
+pnpm run test:e2e
 
 # カバレッジ付きテスト
-npm run test:cov
+pnpm run test:cov
 
 # Watch モード
-npm run test:watch
+pnpm run test:watch
 ```
 
 ### デプロイ
 
-```bash
-# Railway へデプロイ（API）
-# Railway CLIがインストールされている場合
-railway up
+本番は Mac mini + Cloudflare Tunnel。`main` への push で GitHub Actions
+（self-hosted runner `mac-mini-factrail`）が `scripts/deploy.sh` を自動実行する。
+Railway / Vercel は 2026-03-15 に廃止済み。
 
-# Vercel へデプロイ（Web）
-# Vercel CLIがインストールされている場合
-cd apps/web
-vercel deploy
+```bash
+# 手動デプロイ（Mac mini 上で実行）
+cd ~/Projects/factrail
+./scripts/deploy.sh          # 全サービス
+./scripts/deploy.sh api      # API のみ
+./scripts/deploy.sh web      # Web のみ
+
+# GitHub から手動トリガー（workflow_dispatch）
+gh workflow run deploy.yml -f service=web
+```
+
+ビルド不要でサービスを再起動するだけなら launchctl を直接使う。
+`unload` → `load` ではなく `kickstart -k` を使うこと（旧プロセスが残ることがあるため）。
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.sode.factrail-api
+launchctl kickstart -k gui/$(id -u)/com.sode.factrail-web
 ```
 
 ## 主要ファイルの場所
@@ -253,7 +260,7 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```bash
 # デバッグモードで起動
 cd apps/api
-npm run start:debug
+pnpm run start:debug
 
 # VSCodeでデバッグ
 # F5キーを押すか、「実行とデバッグ」パネルから起動
@@ -264,12 +271,22 @@ npm run start:debug
 ```bash
 # API ログ（開発環境）
 cd apps/api
-npm run start:dev
+pnpm run start:dev
 # コンソールにログが出力される
 
-# Railway ログ（本番環境）
-railway logs
+# 本番ログ（Mac mini / launchd の StandardOutPath）
+tail -f ~/Library/Logs/factrail-api.log
+tail -f ~/Library/Logs/factrail-api.error.log
+tail -f ~/Library/Logs/factrail-web.log
+tail -f ~/Library/Logs/factrail-web.error.log
+
+# デプロイのログ（GitHub Actions）
+gh run list --workflow=deploy.yml
+gh run view --log
 ```
+
+> ログは `com.sode.log-rotate`（毎日 04:30）が 50 MiB を超えたものを
+> gzip 5 世代でローテートする。古い分は `*.log.1.gz` 〜 `*.log.5.gz`。
 
 ### データベース確認
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,26 @@ PR/Issue コメントで **`@claude` を生で書かない**（`claude.yml` work
 
 ## CI/CD と GitHub 運用
 
-- ワークフロー: `ci-api.yml`, `ci-web.yml`, `test-api.yml`, `test-web.yml`, `security.yml`, `claude-code-review.yml`
+- ワークフロー: `deploy.yml`, `ci-api.yml`, `ci-web.yml`, `test-api.yml`, `test-web.yml`, `security.yml`, `claude-code-review.yml`, `claude.yml`, `claude-task.yml`, `auto-fix.yml`, `auto-label-issues.yml`, `ci-summary.yml`, `ci-failure-issue.yml`, `docs-update-on-merge.yml`
 - claude-code-action は `id-token: write` 権限が必須（内部で OIDC → App token 交換）
-- ワークフロー変更は **main ブランチと完全一致が必須**（PR で変更すると validation 失敗 → 別 PR で main に先反映）
+- **ワークフロー変更時の cherry-pick が必要なのは、claude-code-action を起動する workflow 自身**（`claude-code-review.yml` / `claude.yml` / `claude-task.yml`）**を変更する場合のみ**。検証対象は「その実行を起動した workflow ファイル 1 個」であって `.github/workflows/*` 全体ではない
+  - それ以外（`security.yml` / `deploy.yml` / `ci-*.yml` / `test-*.yml` 等）の追加・変更は**通常の PR で問題ない**
+  - 実績: PR #160（main に無い workflow を新規追加）、PR #168・#174（`security.yml` / `deploy.yml` を変更）でいずれも claude-review が success
 - 詳細: @.claude/instructions.md (PR 作成時の要件)
+
+## デプロイ
+
+- **本番は Mac mini + Cloudflare Tunnel**（Railway / Vercel は 2026-03-15 に廃止）
+  - API `factrail-api.sode-ai.com` → :3001 / Web `factrail.sode-ai.com` → :3000
+- **経路**: `main` への push（paths フィルタなし・無条件）→ `deploy.yml` → self-hosted runner `mac-mini-factrail`（`~/actions-runner-factrail`, launchd 常駐）→ `scripts/deploy.sh`
+  - 手動起動は `gh workflow run deploy.yml -f service=web`（`workflow_dispatch`）
+- `scripts/deploy.sh` は `git pull --ff-only` → `pnpm install --frozen-lockfile` → `deploy.json` に従いビルド → **`launchctl kickstart -kp` でサービス再起動** → 4 段ヘルスチェック
+  - **プロセスの起動・停止は launchd に委譲している**（自前で `kill` / `nohup` しない）。runner のジョブ終了時 `Cleaning up orphan processes` に起動プロセスが殺されるのを避けるため
+  - ⚠️ **Mac mini の作業ツリーは main に置いておくこと**。`git pull --ff-only` するため、feature ブランチのままだとデプロイが落ちる
+- **プロセス常駐**: launchd `com.sode.factrail-api` / `com.sode.factrail-web`（KeepAlive + ThrottleInterval 10）
+- **ログ**: `~/Library/Logs/factrail-{api,web}{,.error}.log`。`com.sode.log-rotate` が毎日 04:30 に 50 MiB 超を gzip 5 世代でローテート
+- **deploy-hook (:3090) は 2026-07-26 に factrail から切り離し済み**（担当は ai-assistant のみ。factrail 向け webhook も無効化）
+- パッケージマネージャは **pnpm**（2026-04-05 に npm から移行）。`npm ci` / `npm install` を新規に書かない
 
 ## 関連ファイル
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ Factrailは、GitHub、Slack、Googleなど外部サービスで発生するイ�
 - **主要機能**: OAuth設定画面、Webhook設定画面
 
 ### Infrastructure
-- **Deploy**: Railway (API + Redis)
-- **Database**: Supabase (F2Aと共有)
-- **Web**: Vercel
+- **Hosting**: Mac mini（自宅サーバ）+ Cloudflare Tunnel
+  - API: `https://factrail-api.sode-ai.com`（内部 :3001）
+  - Web: `https://factrail.sode-ai.com`（内部 :3000）
+- **Deploy**: GitHub Actions（self-hosted runner）→ `scripts/deploy.sh` → launchd
+- **Database**: Supabase (PostgreSQL・F2Aと共有)
+- **Queue/Session**: Redis (Homebrew, :6379)
+
+> Railway / Vercel は 2026-03-15 に廃止し、Mac mini へ全面移行しました。
 
 ---
 
@@ -39,7 +44,8 @@ Factrailは、GitHub、Slack、Googleなど外部サービスで発生するイ�
 
 ### 前提条件
 
-- Node.js 18+
+- Node.js 20.9+（CI は 20 系、Mac mini は 25 系で稼働）
+- pnpm 10+
 - Supabaseプロジェクト
 - Redis (ローカル開発: Docker)
 
@@ -52,14 +58,11 @@ cd factrail
 
 ### 2. 依存関係インストール
 
-```bash
-# API
-cd apps/api
-npm install
+pnpm workspace のため、**リポジトリルートで一括インストール**します
+（`apps/api` / `apps/web` で個別に実行する必要はありません）。
 
-# Web
-cd apps/web
-npm install
+```bash
+pnpm install
 ```
 
 ### 3. 環境変数設定
@@ -104,17 +107,57 @@ docker run -d -p 6379:6379 redis:alpine
 
 # APIサーバー起動
 cd apps/api
-npm run start:dev
+pnpm run start:dev
 
 # Webサーバー起動（別ターミナル）
 cd apps/web
-npm run dev
+pnpm run dev
 ```
 
 アクセス:
 - API: http://localhost:3001
 - Web: http://localhost:3000
 - Prisma Studio: http://localhost:5555
+
+---
+
+## 🚢 デプロイ
+
+本番は Mac mini 上で稼働し、GitHub Actions の self-hosted runner が自動デプロイします。
+
+```
+main へ push
+  └→ .github/workflows/deploy.yml（paths フィルタなし・無条件発火）
+      └→ self-hosted runner: mac-mini-factrail（launchd 常駐）
+          └→ scripts/deploy.sh
+              ├─ git pull origin main --ff-only
+              ├─ pnpm install --frozen-lockfile（ルートで workspace 一括）
+              └─ deploy.json をループ
+                  ├─ ビルド（pnpm run build）
+                  ├─ launchctl kickstart -kp でサービス再起動
+                  └─ 4 段ヘルスチェック（PID / クラッシュループ / 系統 / HTTP）
+```
+
+**プロセスの起動・停止は launchd に委譲**しています（自前で `kill` / `nohup` しない）。
+runner のジョブ終了処理 `Cleaning up orphan processes` に起動プロセスが殺されるのを避けるためです。
+
+```bash
+# 手動デプロイ（Mac mini 上）
+./scripts/deploy.sh          # 全サービス
+./scripts/deploy.sh api      # API のみ
+
+# GitHub から手動トリガー
+gh workflow run deploy.yml -f service=web
+
+# ビルド不要でサービス再起動だけ
+launchctl kickstart -k gui/$(id -u)/com.sode.factrail-api
+```
+
+> ⚠️ Mac mini の作業ツリーは **main に置いておくこと**。`deploy.sh` が
+> `git pull --ff-only` するため、feature ブランチのままだとデプロイが落ちます。
+
+ログは `~/Library/Logs/factrail-{api,web}{,.error}.log`。
+`com.sode.log-rotate` が毎日 04:30 に 50 MiB 超を gzip 5 世代でローテートします。
 
 ---
 
@@ -161,8 +204,8 @@ npm run dev
 ### ローカルでのClaudeCode使用
 
 ```bash
-# ClaudeCodeをインストール
-npm install -g @anthropic/claude-code
+# ClaudeCodeをインストール（グローバルインストールは npm を使う）
+npm install -g @anthropic-ai/claude-code
 
 # プロジェクトディレクトリで実行
 claude-code
@@ -198,8 +241,14 @@ factrail/
 │   ├── ISSUE_TEMPLATE/
 │   │   └── development.yml      # 開発タスクテンプレート
 │   ├── workflows/
+│   │   ├── deploy.yml           # main push → self-hosted runner でデプロイ
+│   │   ├── ci-api.yml / ci-web.yml
+│   │   ├── test-api.yml / test-web.yml
+│   │   ├── security.yml         # pnpm audit / Snyk / Trivy
 │   │   ├── claude.yml           # Claude自動応答
-│   │   └── claude-code-review.yml
+│   │   ├── claude-code-review.yml
+│   │   └── ...                  # auto-fix, ci-summary, ci-failure-issue 等
+│   ├── dependabot.yml           # 依存の自動更新（土曜 06:00 JST）
 │   └── pull_request_template.md
 └── README.md
 ```
@@ -233,16 +282,14 @@ factrail/
 ## 🧪 テスト
 
 ```bash
-cd apps/api
+# ユニットテスト（リポジトリルートから）
+pnpm --filter api test
 
-# ユニットテスト
-npm run test
-
-# E2Eテスト
-npm run test:e2e
+# E2Eテスト（Playwright / apps/web）
+pnpm --filter web test:e2e
 
 # カバレッジ
-npm run test:cov
+pnpm --filter api test:cov
 ```
 
 ---
@@ -262,18 +309,15 @@ npm run test:cov
 
 #### 使用ツール
 
-1. **npm audit** - npm標準の依存関係脆弱性チェック
+1. **pnpm audit** - 依存関係の脆弱性チェック
 2. **Snyk** - 依存関係とコードの脆弱性スキャン
 3. **Trivy** - ファイルシステムとIaC設定のスキャン
 
 #### ローカルでのセキュリティチェック
 
 ```bash
-# npm auditを実行（API）
-npm run audit:api
-
-# npm auditを実行（Web）
-npm run audit:web
+# 依存の脆弱性チェック（CI の pnpm-audit ジョブと同じ）
+pnpm audit --prod --audit-level high
 
 # Snykを実行（事前にSnyk CLIのインストールと認証が必要）
 cd apps/api


### PR DESCRIPTION
## 背景

PR #174（デプロイの launchctl 化）の調査で、ドキュメントが実態から大きく乖離していることが判明しました。

**特に実害があったのが `.claude/quickref.md`** です。Claude Code が参照するファイルに、既に存在しないインフラへのコマンドが**実行可能な形で**書かれていました:

```bash
railway up          # Railway は 2026-03-15 に廃止済み
vercel deploy       # 同上
railway logs
```

## 変更内容

### `.claude/quickref.md`（実害最大）

| before | after |
|---|---|
| `railway up` / `vercel deploy` | `./scripts/deploy.sh` / `gh workflow run deploy.yml` / `launchctl kickstart -k` |
| `railway logs` | `~/Library/Logs/factrail-*.log` の tail / `gh run list --workflow=deploy.yml` |
| `npm install`（apps 配下で個別に） | `pnpm install`（workspace のためルートで一括） |

### `CLAUDE.md`

- **デプロイの記述が皆無だった**ため新規セクションを追加（経路 / launchd への委譲 / ログ / 「Mac mini の作業ツリーは main に置く」注意）
- workflow 一覧に `deploy.yml` ほか 8 件が欠落していたのを補完
- **「ワークフロー変更は main と完全一致が必須」を実態に合わせて限定** — 検証対象は「その実行を起動した workflow ファイル 1 個」であり、cherry-pick が必要なのは claude-code-action を起動する workflow 自身（`claude-code-review.yml` 等）を変更する場合のみです

  実績: PR #160（main に無い workflow を新規追加）、PR #168・#174（`security.yml` / `deploy.yml` を変更）で**いずれも claude-review が success**

### `.claude/context.md`

- `API Deploy: Railway` / `Web Deploy: Vercel` → Mac mini + Cloudflare Tunnel
- `Current branch: claude/issue-4-slack-dm-dispatch` のような陳腐化した記述を削除

### `README.md`

- Infrastructure から Railway / Vercel を除去
- **デプロイセクションを新規追加**（フロー図・手動デプロイ・注意点）
- npm → pnpm。存在しない `npm run audit:api` を実在する `pnpm audit --prod --audit-level high` に修正
- Claude Code のパッケージ名を `@anthropic-ai/claude-code` に修正（グローバルインストールなので npm のまま）
- `Node.js 18+` → `20.9+`、プロジェクト構造の workflows 一覧を更新

## 検証

```
Railway / Vercel の残存（廃止注記を除く）: 0 件
npm install / npm run の残存（グローバルインストールを除く）: 0 件
```

`audit:api` / `audit:web` はどの `package.json` にも存在しないスクリプトだったため、実在するコマンドに置き換えています。

## スコープ外

`docs/` 配下（4 ファイル）と Vault 側の Factrail 系ドキュメントにも Railway/Vercel 前提の記述が残っていますが、参照頻度が低いため本 PR では触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)