### PR TITLE
chore(deps): 間接依存の HIGH 脆弱性を系列別 override で解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,15 @@
       "ws": ">=8.20.1 <9",
       "postcss": ">=8.5.23 <9",
       "sharp": ">=0.35.3 <0.36",
+      "brace-expansion@1": ">=1.1.16 <2",
+      "brace-expansion@2": ">=2.1.2 <3",
+      "brace-expansion@5": ">=5.0.8 <6",
+      "fast-uri@3": ">=3.1.4 <4",
+      "js-yaml@3": ">=3.15.0 <4",
+      "js-yaml@4": ">=4.3.0 <5",
+      "glob@10": ">=10.5.0 <11",
+      "picomatch@4": ">=4.0.4 <5",
+      "tmp": ">=0.2.7 <0.3",
       "express>path-to-regexp": "0.1.13"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,15 @@ overrides:
   ws: '>=8.20.1 <9'
   postcss: '>=8.5.23 <9'
   sharp: '>=0.35.3 <0.36'
+  brace-expansion@1: '>=1.1.16 <2'
+  brace-expansion@2: '>=2.1.2 <3'
+  brace-expansion@5: '>=5.0.8 <6'
+  fast-uri@3: '>=3.1.4 <4'
+  js-yaml@3: '>=3.15.0 <4'
+  js-yaml@4: '>=4.3.0 <5'
+  glob@10: '>=10.5.0 <11'
+  picomatch@4: '>=4.0.4 <5'
+  tmp: '>=0.2.7 <0.3'
   express>path-to-regexp: 0.1.13
 
 importers:
@@ -1980,15 +1989,15 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2817,8 +2826,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2830,7 +2839,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4 <5'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3046,8 +3055,8 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
@@ -3566,12 +3575,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4127,10 +4136,6 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -4294,10 +4299,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.1:
-    resolution: {integrity: sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -5001,9 +5002,9 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -5457,7 +5458,7 @@ snapshots:
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       jsonc-parser: 3.2.1
-      picomatch: 4.0.1
+      picomatch: 4.0.4
       rxjs: 7.8.1
       source-map: 0.7.4
     optionalDependencies:
@@ -5939,7 +5940,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5953,7 +5954,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6114,7 +6115,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -6366,7 +6367,7 @@ snapshots:
       cli-table3: 0.6.5
       commander: 4.1.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1)
-      glob: 10.4.5
+      glob: 10.5.0
       inquirer: 8.2.6
       node-emoji: 1.11.0
       ora: 5.4.1
@@ -7275,7 +7276,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7531,16 +7532,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7825,7 +7826,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.7.2):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8347,7 +8348,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -8519,7 +8520,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.7
 
   fast-check@3.23.2:
     dependencies:
@@ -8543,7 +8544,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:
@@ -8783,7 +8784,7 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.4.5:
+  glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
@@ -9539,12 +9540,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -10010,15 +10011,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -10234,8 +10235,6 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  os-tmpdir@1.0.2: {}
-
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -10397,8 +10396,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.1: {}
 
   picomatch@4.0.4: {}
 
@@ -11190,9 +11187,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
## 背景

PR #168 で Dependabot alerts を有効化したところ、**HIGH 13 件**が検出されました。すべて間接依存（transitive）で、パッケージとしては 6 種類です。

Trivy がこれらを検出していないのは、GitHub Advisory Database と Trivy の DB で対象範囲・反映速度が異なるためです（推測を含みます）。

## なぜ単純な override では駄目なのか

これらのパッケージは**複数のメジャー系列が同居**しています。

| パッケージ | lockfile 上の実態 |
|---|---|
| `brace-expansion` | **1.1.13 / 2.0.3 / 5.0.5** の 3 系列 |
| `js-yaml` | **3.14.2 / 4.1.1** の 2 系列 |
| `picomatch` | **2.3.2 / 4.0.1 / 4.0.4** の 3 系列 |
| `glob` | **7.2.3 / 10.4.5** の 2 系列 |

`"brace-expansion": ">=5.0.8"` のように一つのレンジで指定すると、1.x / 2.x を要求するパッケージまで 5.x に強制されます。**実際に検証したところ `minimatch` が実行時に落ちました**:

```
TypeError: expand is not a function
TypeError: (0 , brace_expansion_1.default) is not a function
```

brace-expansion 5.0.8 は CJS のデフォルトエクスポートを廃止しているためです。

## 対応: pnpm の package selector 付き override

pnpm は `"pkg@<major>"` というキーで**系列ごとの override** を書けます（`pnpm.io/settings` の overrides 節に記載）。隔離環境で「1.x を要求する依存」と「2.x を要求する依存」を同居させて実験し、**両者が別々に引き上がること**を確認したうえで採用しました。

| パッケージ | before | after | 備考 |
|---|---|---|---|
| `brace-expansion@1` | 1.1.13 | **1.1.16** | |
| `brace-expansion@2` | 2.0.3 | **2.1.2** | |
| `brace-expansion@5` | 5.0.5 | **5.0.8** | |
| `fast-uri@3` | 3.1.0 | **3.1.4** | 連鎖する 4 件の advisory の最終版 |
| `js-yaml@3` | 3.14.2 | **3.15.0** | |
| `js-yaml@4` | 4.1.1 | **4.3.0** | |
| `glob@10` | 10.4.5 | **10.5.0** | `glob@7.2.3` は advisory 範囲外（`>=10.2.0 <10.5.0`）のため**据え置き** |
| `picomatch@4` | 4.0.1 | **4.0.4** | `picomatch@2.3.2` は範囲外（`>=4.0.0 <4.0.4`）のため**据え置き** |
| `tmp` | 0.0.33 | **0.2.7** | 系列が 1 本なので selector なし |

### セレクタはメジャー系列で書く必要がある

pnpm のマッチ判定は「解決済みバージョンとの一致」ではなく **`semver.intersects`（依存側の宣言レンジとの交差）** です。したがって advisory の修正後レンジ（`"brace-expansion@>=1.1.16"` など）をセレクタに書くと `^1.1.7` / `^2.0.1` / `^5.0.5` のすべてと交差してしまい、**全系列が誤って巻き込まれます**。実験でこの誤爆も再現しています。

### `tmp` は 0.2.6 ではなく 0.2.7

alert が示す修正版は 0.2.6 ですが、**`GHSA-7c78-jf6q-g5cm`（Type-confusion bypass of `_assertPath`）が `>=0.2.6 <0.2.7` を脆弱**としています。0.2.6 で止めると別の alert が立つため 0.2.7 を下限にしました。

`tmp` は 0.0.x → 0.2.x と 0.x での実質メジャー更新なので、唯一の消費者である `external-editor`（`@nestjs/cli` > `@angular-devkit/schematics-cli` > `inquirer` 経由）を実際に動かして確認しています。

## 検証

| 項目 | 結果 |
|---|---|
| **lockfile の差分** | 対象 6 パッケージ + `os-tmpdir` 削除（tmp 0.2.x が不要にした）**のみ** |
| 解決パッケージ集合の diff | 対象以外の依存は**一切動いていない**ことを機械的に確認 |
| `pnpm install --frozen-lockfile` | ✅ OK |
| `pnpm --filter api build` / `test` | ✅ 成功 / **288 passed, 26 suites** |
| `pnpm --filter web build` / `lint` | ✅ 成功 / **0 errors** |
| **Trivy (v0.72.0) HIGH,CRITICAL** | ✅ **0 件** |
| `pnpm audit --prod --audit-level high` | ✅ **HIGH 0 件**（low 1 / moderate 3 は閾値未満） |
| `tmp` の実動作 | ✅ `external-editor` で一時ファイル作成・cleanup が成功 |
| `brace-expansion` の実動作 | ✅ `minimatch` が正常動作（5.x 一律強制では落ちていた） |

## 解消しきれない 2 件について

`brace-expansion` の **`GHSA-mh99-v99m-4gvg`** だけは override では解消できません。

- vulnerable range が**下限なしの `<= 5.0.7`**、`first_patched_version` は **5.0.8 のみ**（メジャー別のバックポートが存在しない）
- したがって 1.1.16 も 2.1.2 も semver 上この範囲に入る
- しかし 5.0.8 に強制すると前述のとおり**実行時に壊れる**
- npm 上に 1.1.17 / 2.1.3 は存在しない（確認済み）

残る 2 件の経路はいずれも **devDependencies のみ**です:

```
apps/api > @nestjs/cli > fork-ts-checker-webpack-plugin > minimatch > brace-expansion@1
apps/api > @nestjs/cli > glob > minimatch > brace-expansion@2
```

`@nestjs/cli` を最新の 11.x に上げても `brace-expansion@1.1.16` は残ることを確認しています。**上流が 1.1.17 / 2.1.3 をバックポートするのを待つか、Dependabot 側で dismiss（理由: no fix available / dev-dependency only）する**しかありません。マージ後に dismiss するかはご判断ください。

## 実リスク評価（参考）

これらはすべて間接依存で、factrail のコードから直接 import しているものはありません。

| パッケージ | 発火条件 | factrail での経路 |
|---|---|---|
| `glob` | **CLI の `-c/--cmd`** オプション | ライブラリとして import しているのみで CLI は未使用 |
| `js-yaml` | 攻撃者制御の YAML を parse | jest のカバレッジ設定読み込み（devDependencies） |
| `brace-expansion` / `picomatch` | 攻撃者が glob パターンを制御 | ビルドツールの内部利用のみ |
| `tmp` | prefix/postfix に攻撃者制御の値 | `@nestjs/cli` の対話プロンプト（開発時のみ） |
| `fast-uri` | JSON Schema バリデーション経由の URI | ajv の内部利用 |

CI を通すことと将来の攻撃面を残さないことが目的で、現時点で実際に踏める経路は見当たりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
