### PR TITLE
fix(web): E2E の networkidle 待ちをやめて描画要素を待つ

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -17,13 +17,19 @@ test.describe('ホームページ', () => {
   test('ページに主要なコンテンツが表示されること', async ({ page }) => {
     await page.goto('/');
 
-    // ページが完全に読み込まれるまで待機
-    await page.waitForLoadState('networkidle');
+    // "/" は /facts へリダイレクトされ、未認証だと AuthGuard が /login へ送る。
+    // CI は常に未認証（localStorage が空）なので、到達先は /login で確定する。
+    await expect(page).toHaveURL(/\/login$/);
 
-    // ページの基本的な構造を確認
-    // Note: 実際のUIコンポーネントに応じて調整が必要
-    const body = page.locator('body');
-    await expect(body).toBeVisible();
+    // 待機に networkidle は使わない。通信が止まる保証がなくタイムアウトしていた (Issue #171)。
+    // 代わりにログイン画面の実要素が描画されるのを待つ。
+    // これでリダイレクトの連鎖 ("/" → /facts → /login) が最後まで通ったことも確認できる。
+    await expect(
+      page.getByRole('heading', { name: 'ようこそ' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'ログイン', exact: true }),
+    ).toBeVisible();
   });
 
   test('ページが5秒以内に読み込まれること（パフォーマンステスト）', async ({


### PR DESCRIPTION
## 概要

`Web E2E Tests` が main で失敗して Issue #171 が自動起票されたまま 7/26 から放置されていた。失敗 run のアーティファクトが本日 16:42 JST に期限切れになる直前だったため退避し、原因を特定した上で修正する。

`Fixes #171`

## 原因

失敗していたのは `e2e/home.spec.ts:17` の `page.waitForLoadState('networkidle')` で、30 秒のテストタイムアウトに 3 回（初回 + リトライ2回）とも到達していた。

退避したスクリーンショット・trace から分かったこと:

- 失敗時点の到達先は **`/login`**。`"/"` → `/facts` → `AuthGuard`（`src/components/auth/AuthGuard.tsx:27`）が未認証で `/login` へ push している
- trace 上に `localhost:3001` / `:8001` への API リクエストは **0 件**。`/facts` のデータ取得までは到達していない
- 一方 **同じコードで PR #170 / #172 の web-e2e は 7/31 に SUCCESS**（[Web E2E Tests の run 履歴](https://github.com/sode0417/factrail/actions/workflows/test-web.yml)）

つまり恒久的な不具合ではなく **`networkidle` という待ち方に起因する flaky**。`networkidle` は「500ms 通信が途切れる」ことを条件にする待ち方で、[Playwright 公式がテストでの使用を明確に非推奨としている](https://playwright.dev/docs/api/class-page#page-wait-for-load-state)。

なお `main` は 7/26 以降 `apps/web/**` を一度も変更していないため、paths フィルタで **Web E2E がその後一度も再実行されていない**（＝赤のまま放置されていた）。

## 変更内容

`apps/web/e2e/home.spec.ts` の 2 番目のテストのみ変更。**プロダクションコードは無変更**。

- `waitForLoadState('networkidle')` を削除し、到達先で必ず描画される要素（`ようこそ` 見出し / `ログイン` ボタン）を待つ決定的な待ちに置き換え
- 併せて `toHaveURL(/\/login$/)` を追加し、リダイレクトの連鎖（`"/"` → `/facts` → `/login`）が最後まで通ったことを検証
- 常に真で何も検証していなかった `expect(page.locator('body')).toBeVisible()` を上記に置き換え

## 動作確認エビデンス

CI と同じ条件（`CI=true` / `next start` / `retries: 2` / `workers: 1`）を、本番 factrail-web が占有する :3000 を避けて :4000 で再現。

**修正後 — 3件すべて pass**

```
Running 3 tests using 1 worker

  ✓  1 [chromium] › e2e/home.spec.ts:8:7 › ホームページ › ページが正常に読み込まれること (1.2s)
  ✓  2 [chromium] › e2e/home.spec.ts:17:7 › ホームページ › ページに主要なコンテンツが表示されること (281ms)
  ✓  3 [chromium] › e2e/home.spec.ts:35:7 › ホームページ › ページが5秒以内に読み込まれること（パフォーマンステスト） (153ms)

  3 passed (3.9s)
```

対象テストは **30 秒タイムアウト → 281ms**。

**正直な但し書き**: 旧実装（`networkidle` 版）も同じローカル環境では 1.0s で pass する。ローカルでは flaky が再現しないため、本 PR は「再現した不具合の修正」ではなく **flaky を生む待ち方そのものの排除** という位置づけ。最終的な確認は本 PR の `web-e2e` と、マージ後に main で走る `Web E2E Tests` が緑になることで行う。

## レビュアーの動作確認手順

```bash
cd apps/web
CI=true pnpm run build
CI=true pnpm run test:e2e
```

> ⚠️ Mac mini 上で実行する場合、`playwright.config.ts` の webServer は :3000 固定で、本番 factrail-web と衝突する。ポートを逃がすか別マシンで実行すること。

## 確認用チェックリスト

- [x] 対象テストがローカル（CI 相当条件）で pass
- [x] 他 2 件のテストにデグレなし
- [x] プロダクションコードに変更がないこと
- [ ] 本 PR の `web-e2e` が SUCCESS
- [ ] マージ後、main の `Web E2E Tests` が SUCCESS

## 残課題（本 PR のスコープ外）

E2E は現状スモークテスト 3 件のみで、テストデータを使った実質的な検証がない。テスト基盤の充実は別 Issue として起票する。