### PR TITLE
docs: claude-review の Dependabot スキップと E2E の待ち方を規約に反映

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -264,6 +264,31 @@ async createFact(dto: CreateFactDto) {
 [name].e2e.ts     # E2Eテスト
 ```
 
+### Playwright E2E の待ち方
+
+**`page.waitForLoadState('networkidle')` を使わないこと。**
+
+- **理由**: 「500ms 通信が途切れる」という条件は、ポーリング・プリフェッチ・
+  リダイレクトの連鎖があると成立するタイミングが実行環境に左右され、flaky になる。
+  Playwright 公式もテストでの使用を非推奨としている
+- **代わりに**: 到達先で必ず描画される要素をロケータで待つ
+  （`expect(page.getByRole(...)).toBeVisible()` 等）。
+  URL 遷移を確認したい場合は `expect(page).toHaveURL(...)` を併用する
+- **根拠**: Issue #171。CI で 30 秒タイムアウトして main の CI が赤いまま 1 週間放置された。
+  同じコードでも run によって成功したり失敗したりしていた
+
+```typescript
+// ❌ 悪い例（通信が止まる保証がない）
+await page.goto('/');
+await page.waitForLoadState('networkidle');
+await expect(page.locator('body')).toBeVisible(); // body は常に可視で無意味
+
+// ✅ 良い例（描画される要素を決定的に待つ）
+await page.goto('/');
+await expect(page).toHaveURL(/\/login$/);
+await expect(page.getByRole('heading', { name: 'ようこそ' })).toBeVisible();
+```
+
 ### テスト記述の原則
 
 **重要**: テストの`describe`と`it`は、ドメインに即した**日本語**で記述すること。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,8 +48,13 @@ updates:
     open-pull-requests-limit: 3
 
     # 自動リベースを止める。リベースのたびに synchronize イベントが発火して
-    # claude-code-review.yml が起動する (= Claude クレジットを消費する) ため。
+    # CI 一式 (API CI / Web CI / API Tests / Web E2E / Security Scan) が回り直すため。
     # 週内にマージする運用なので陳腐化のリスクは小さい。
+    #
+    # ⚠️ 2026-08-02 補足: 元の理由は「claude-code-review.yml が起動して Claude クレジットを
+    # 消費するため」だったが、#158 の対応で claude-review は Dependabot 起動の run では
+    # スキップされるようになったため、その理由はもう成立しない。
+    # 手動の `@dependabot rebase` はこの設定に関係なく使える。
     rebase-strategy: 'disabled'
 
     labels:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ PR/Issue コメントで **`@claude` を生で書かない**（`claude.yml` work
 
 - ワークフロー: `deploy.yml`, `ci-api.yml`, `ci-web.yml`, `test-api.yml`, `test-web.yml`, `security.yml`, `claude-code-review.yml`, `claude.yml`, `claude-task.yml`, `auto-fix.yml`, `auto-label-issues.yml`, `ci-summary.yml`, `ci-failure-issue.yml`, `docs-update-on-merge.yml`
 - claude-code-action は `id-token: write` 権限が必須（内部で OIDC → App token 交換）
+- **claude-review は Dependabot 起動の PR ではスキップされる**（`claude-code-review.yml` の `if: github.actor != 'dependabot[bot]'`）。Dependabot 起動の run は Actions ではなく **Dependabot のシークレットストア**を参照するため `secrets.CLAUDE_CODE_OAUTH_TOKEN` が空になり、必ず失敗するのを避けるため。依存更新の安全性は Trivy / Snyk / pnpm audit が担保する（#158）
+  - claude bot 起票の PR（Phase 1 のドラフト PR）は `allowed_bots: 'claude'` で許可済み
 - **ワークフロー変更時の cherry-pick が必要なのは、claude-code-action を起動する workflow 自身**（`claude-code-review.yml` / `claude.yml` / `claude-task.yml`）**を変更する場合のみ**。検証対象は「その実行を起動した workflow ファイル 1 個」であって `.github/workflows/*` 全体ではない
   - それ以外（`security.yml` / `deploy.yml` / `ci-*.yml` / `test-*.yml` 等）の追加・変更は**通常の PR で問題ない**
   - 実績: PR #160（main に無い workflow を新規追加）、PR #168・#174（`security.yml` / `deploy.yml` を変更）でいずれも claude-review が success


### PR DESCRIPTION
## 概要

Issue #158 / #171 の対応で確定した内容を、次に同じことを踏まないようドキュメント側へ落とす。**コード変更なし・ドキュメントとコメントのみ**。

## 変更内容

### 1. `CLAUDE.md` — CI/CD 節

claude-review が Dependabot 起動の PR でスキップされることと、その理由を追記。

Dependabot 起動の workflow run は **Actions ではなく Dependabot のシークレットストア**を参照するため `secrets.CLAUDE_CODE_OAUTH_TOKEN` が空になる（run ログの `Secret source: Dependabot` / `"claude_code_oauth_token": ""` と、`gh secret list --app dependabot` が空であることで確認済み）。この事実は今回まで記録されていなかったため、同じ調査を繰り返さないよう明記する。

### 2. `.github/dependabot.yml` — `rebase-strategy: 'disabled'` の理由

元のコメントは「リベースのたびに `claude-code-review.yml` が起動する（= Claude クレジットを消費する）ため」だったが、**#158 の対応でその理由は成立しなくなった**。

設定自体は据え置き（CI 一式が回り直すコストは残るため）。理由の記述だけ実態に合わせた。

### 3. `.claude/instructions.md` — テスト規約に「Playwright E2E の待ち方」を新設

`page.waitForLoadState('networkidle')` を使わない方針と、代替（ロケータで待つ / `toHaveURL` を併用）を良い例・悪い例つきで明記。#171 の再発防止。

## 背景（今回の実測結果）

| 事実 | 根拠 |
|---|---|
| Dependabot PR 4本が滞留していた原因は `claude-review` のみで、他のチェックは全て SUCCESS だった | `gh pr checks` |
| エラーは `Workflow initiated by non-human actor: dependabot (type: Bot)` | run 30665786290 |
| `allowed_bots` を足すだけでは通らない（トークンが空のため） | 上記シークレットストアの件 |
| 対応後、Dependabot PR の `claude-review` は **skipped** になり `mergeStateStatus` が CLEAN に | #172 / #170 で確認 |
| #171 は恒久バグではなく flaky（ローカルでは旧実装も 1.0s で pass） | #179 の検証 |

## レビュアーの動作確認手順

ドキュメントのみのため動作確認は不要。`.github/dependabot.yml` の YAML 構文だけ確認済み（パース OK / `updates` 2 件）。

## 確認用チェックリスト

- [x] `dependabot.yml` が YAML としてパースできること
- [x] コード変更が含まれていないこと
- [ ] `claude-review` が SUCCESS（人間起票の PR でスキップされないことの確認を兼ねる）

## 関連

- #158 — claude-review が bot 起動 PR で失敗する（本 PR で対応内容を文書化）
- #171 — Web E2E の flaky
- #179 — #171 の修正 PR
- #180 — E2E 拡充（`networkidle` 禁止の規約化は本 PR で先行実施）